### PR TITLE
Fix ext_emconf.php

### DIFF
--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -7,7 +7,7 @@
  * @author   Tim Lochmüller
  */
 
-$EM_CONF['calendarize'] = array(
+$EM_CONF[$_EXTKEY] = array(
     'title'            => 'Calendarize',
     'description'      => 'Create a structure for timely controlled tables and one plugin for the different output of calendar views. The extension is shipped with one default event table, but the aim of the extension is to "calendarize" every table/model. It is completely independent and configurable! Use your own models as event items in this calender. We need feedback about the concept! Development on https://github.com/lochmueller/calendarize',
     'category'         => 'fe',


### PR DESCRIPTION
Having a non standard ext_emconf.php breaks existing code
that reads the content of this file (e.g. composer install).