### PR TITLE
Set end time to 23:59:59 if empty (optional field).

### DIFF
--- a/Classes/Service/TimeTable/AbstractTimeTable.php
+++ b/Classes/Service/TimeTable/AbstractTimeTable.php
@@ -20,6 +20,11 @@ abstract class AbstractTimeTable extends AbstractService
 {
 
     /**
+     * Seconds of 23:59:59 that mark the day end
+     */
+    const DAY_END = 86399;
+
+    /**
      * Time table service
      *
      * @var \HDNET\Calendarize\Service\TimeTableService

--- a/Classes/Service/TimeTable/ExternalTimeTable.php
+++ b/Classes/Service/TimeTable/ExternalTimeTable.php
@@ -23,11 +23,6 @@ class ExternalTimeTable extends AbstractTimeTable
 {
 
     /**
-     * Seconds of 23:59:59 that mark the day end in the ICS parser
-     */
-    const DAY_END = 86399;
-
-    /**
      * ICS reader service
      *
      * @var \HDNET\Calendarize\Service\IcsReaderService

--- a/Classes/Service/TimeTable/TimeTimeTable.php
+++ b/Classes/Service/TimeTable/TimeTimeTable.php
@@ -36,7 +36,7 @@ class TimeTimeTable extends AbstractTimeTable
             'start_date' => $configuration->getStartDate(),
             'end_date'   => $configuration->getEndDate() ?: $configuration->getStartDate(),
             'start_time' => $startTime,
-            'end_time'   => $endTime,
+            'end_time'   => $endTime == 0 ? self::DAY_END : $endTime,
             'all_day'    => $configuration->isAllDay(),
         ];
         $times[] = $baseEntry;


### PR DESCRIPTION
I do not use end_time, so it this field is 0 which is interpreted as time 0:00.

1. the calendar view adds class hasEvent also to the day before the events 
2. the editor sees in the backend as Calendarize Information "16:00 - 0:00"

With this patch there will be shown 23:59 which is less irritating and the calendar view works correctly.