### PR TITLE
Fix redirect loop

### DIFF
--- a/Classes/Controller/CalendarController.php
+++ b/Classes/Controller/CalendarController.php
@@ -295,7 +295,7 @@ class CalendarController extends AbstractController
                 if (!MathUtility::canBeInterpretedAsInteger($this->settings['listPid'])) {
                     return TranslateUtility::get('noEventDetailView');
                 }
-                $this->redirect('list', null, null, [], null, $this->settings['listPid'], 301);
+                $this->redirect('list', null, null, [], $this->settings['listPid'], 0, 301);
             }
         }
 


### PR DESCRIPTION
Wrong arguments are passed to the redirect function. The pageUid is null which seems to point to current page and therefore creates a redirect loop with delay set to the value of listPid.
see https://docs.typo3.org/typo3cms/ExtbaseFluidBook/b-ExtbaseReference/Index.html?highlight=redirect#most-important-api-methods-of-action-controller