### PR TITLE
fix documentation in IndexTraversingViewHelper

### DIFF
--- a/Classes/ViewHelpers/IndexTraversingViewHelper.php
+++ b/Classes/ViewHelpers/IndexTraversingViewHelper.php
@@ -17,7 +17,7 @@ use TYPO3\CMS\Extbase\Persistence\QueryInterface;
  *
  * <code title="Traversing thru future and past occurings of the event">
  * {namespace c=HDNET\Calendarize\ViewHelpers}
- * <f:for each="{c:indexTraversing(index:'{index}', future: 'true', past: 'false', limit: 10, sort: 'ASC')}" as="futureEvent">
+ * <f:for each="{c:indexTraversing(index:'{index}', future: 1, past: 0, limit: 10, sort: 'ASC')}" as="futureEvent">
  *  <f:debug>{futureEvent}</f:debug>
  * </f:for>
  * </code>


### PR DESCRIPTION
casting of bool-values in string don't work. so using numbers to represent the boolean values