### PR TITLE
Fix findList() not showing today's events because of timezone mixup

### DIFF
--- a/Classes/Utility/DateTimeUtility.php
+++ b/Classes/Utility/DateTimeUtility.php
@@ -136,7 +136,8 @@ class DateTimeUtility
     }
 
     /**
-     * Get a normalized date time object
+     * Get a normalized date time object. The timezone of the returned object is
+     * UTC for integer parameters and server timezone for everything else.
      *
      * @param int|null|string|\DateTime $dateInformation
      *
@@ -151,7 +152,7 @@ class DateTimeUtility
             // The $timezone parameter and the current timezone are ignored [ie. set to UTC] when the $time parameter [...] is a UNIX timestamp (e.g. @946684800) [...]
             return new \DateTime("@$dateInformation");
         } elseif (is_string($dateInformation)) {
-            return new \DateTime($dateInformation, DateTimeUtility::getTimeZone());
+            return new \DateTime($dateInformation);
         }
         else {  // null
             return self::getNow();
@@ -166,7 +167,8 @@ class DateTimeUtility
      */
     public static function getNow()
     {
-        // \DateTime::ATOM contains the timezone "T", so the generated \DateTime has a (the current) timezone
+        // NOTE that new \DateTime('@timestamp') does NOT work - @see comment in normalizeDateTimeSingle()
+        // So we create a date string with timezone information first, and a \DateTime in the current servert timezone then.
         return new \DateTime(date(\DateTime::ATOM, (int) $GLOBALS['SIM_ACCESS_TIME']));
     }
 }

--- a/Classes/Utility/DateTimeUtility.php
+++ b/Classes/Utility/DateTimeUtility.php
@@ -155,12 +155,14 @@ class DateTimeUtility
     }
 
     /**
-     * Get the current Date (normalized optimized for queries, because SIM_ACCESS_TIME is rounded to minutes)
+     * Get the current date (normalized optimized for queries, because SIM_ACCESS_TIME is rounded to minutes)
+     * in the current timezone.
      *
      * @return \DateTime
      */
     public static function getNow()
     {
-        return self::normalizeDateTimeSingle((int)$GLOBALS['SIM_ACCESS_TIME']);
+        // \DateTime::ATOM contains the timezone "T", so the generated \DateTime has a (the current) timezone
+        return new \DateTime(date(\DateTime::ATOM, (int) $GLOBALS['SIM_ACCESS_TIME']));
     }
 }

--- a/Classes/Utility/DateTimeUtility.php
+++ b/Classes/Utility/DateTimeUtility.php
@@ -136,7 +136,7 @@ class DateTimeUtility
     }
 
     /**
-     * Get a normalize date time object
+     * Get a normalized date time object
      *
      * @param int|null|string|\DateTime $dateInformation
      *
@@ -147,11 +147,15 @@ class DateTimeUtility
         if ($dateInformation instanceof \DateTime) {
             return $dateInformation;
         } elseif (MathUtility::canBeInterpretedAsInteger($dateInformation)) {
-            $dateInformation = '@' . $dateInformation;
-        } elseif (!is_string($dateInformation)) {
+            // http://php.net/manual/en/datetime.construct#refsect1-datetime.construct-parameters :
+            // The $timezone parameter and the current timezone are ignored [ie. set to UTC] when the $time parameter [...] is a UNIX timestamp (e.g. @946684800) [...]
+            return new \DateTime("@$dateInformation");
+        } elseif (is_string($dateInformation)) {
+            return new \DateTime($dateInformation, DateTimeUtility::getTimeZone());
+        }
+        else {  // null
             return self::getNow();
         }
-        return new \DateTime($dateInformation, DateTimeUtility::getTimeZone());
     }
 
     /**


### PR DESCRIPTION
**Bug**: listAction() (without parameters) does not show today's events if the server timezone is > UTC, eg. UTC+1 / CET

**Problem**: findList() (without $overrideStartDate) uses query parameters with mixed timezones, which generates a incorrect query that excludes the current day

**Details**:

* findList() (without $overrideStartDate) generates $startTimestamp from $now = DateTimeUtility::getNow() - a DateTime in UTC which is set to 00:00:00 and converted back to an unix timestamp:

  (new \DateTime('2016-11-24T00:00:00+00:00'))->getTimestamp(): 1479945600

* This unix timestamp is range checked against start_date in the database table tx_calendarize_domain_model_index. The Problem: start_date, like all TYPO3 timestamp fields, are not real unix timestamps, ie. the number of seconds since 1970-01-01 00:00:00 ***UTC***, but the number of seconds since 1970-01-01 00:00:00 ***Server timezone***. (see https://forge.typo3.org/issues/32081#Note-about-the-rationale-of-not-using-UTC-in-the-database for the sad details). So if the server timezone is CET - which will be the case for many TYPO3 installations - start_date will be one hour or 3600 secs *less* than the real utc based $now unix timestamp:

  (new \DateTime('2016-11-24T00:00:00+01:00'))->getTimestamp(): 1479942000

* This makes the query used to list the events after 00:00:00 today compare apples with oranges:

    SELECT * FROM tx_calendarize_domain_model_index
    WHERE start_date (utc + 1) >= now (utc)

  for the current day's event actually becomes

    SELECT * FROM tx_calendarize_domain_model_index
    WHERE 1479942000 >= 1479945600

  which obviously does not return a result, and thus events of the current day are not displayed.

**Fix**: Compare values in the same timezones. As all DB values are server timezone, we should use that for comparison, ie. bring $now into server timezone for comparison.

**Note**: The mixup of server timezone based events and UTC based dates might be a reason for a few other bugs, eg. #113.