### PR TITLE
IndexRepository::findBySearch more open to slot-modification

### DIFF
--- a/Classes/Domain/Repository/IndexRepository.php
+++ b/Classes/Domain/Repository/IndexRepository.php
@@ -149,8 +149,8 @@ class IndexRepository extends AbstractRepository
         $this->addTimeFrameConstraints(
             $constraints,
             $query,
-            $startDate instanceof \DateTime ? $startDate->getTimestamp() : null,
-            $endDate instanceof \DateTime ? $endDate->getTimestamp() : null
+            $arguments['startDate'] instanceof \DateTimeInterface ? $arguments['startDate']->getTimestamp() : null,
+            $arguments['endDate'] instanceof \DateTimeInterface ? $arguments['endDate']->getTimestamp() : null
         );
 
         if ($arguments['indexIds']) {


### PR DESCRIPTION
Use now the startDate and endDate from the findBySearch slot-arguments
Use the DateTimeInterface instead of DateTime because you can also use DateTimeImmutable here