### PR TITLE
Revert "Set language mode to content_fallback for the index selection…

### DIFF
--- a/Classes/Domain/Repository/IndexRepository.php
+++ b/Classes/Domain/Repository/IndexRepository.php
@@ -86,20 +86,6 @@ class IndexRepository extends AbstractRepository
     }
 
     /**
-     * Returns a query for objects of this repository
-     *
-     * @return \TYPO3\CMS\Extbase\Persistence\QueryInterface
-     * @api
-     */
-    public function createQuery()
-    {
-        $query = parent::createQuery();
-        $query->getQuerySettings()
-            ->setLanguageMode("content_fallback");
-        return $query;
-    }
-
-    /**
      * Find List
      *
      * @param int        $limit


### PR DESCRIPTION
…", because it breaks sites with sys_language_mode != 'content_fallback'. See https://github.com/lochmueller/calendarize/commit/2c552df7dafceb6460740983ff62ecb048fb8f76.

This reverts commit 2c552df7dafceb6460740983ff62ecb048fb8f76.