### PR TITLE
Plugin Hashes for Feed Formats

### DIFF
--- a/Resources/Private/Templates/Calendar/List.html
+++ b/Resources/Private/Templates/Calendar/List.html
@@ -5,9 +5,9 @@
 	<f:flashMessages />
 
 	<f:comment>
-		<f:link.action action="list" format="xml">RSS</f:link.action>
-		<f:link.action action="list" format="atom">Atom</f:link.action>
-		<f:link.action action="list" format="ics">iCal</f:link.action>
+		<f:link.action action="list" format="xml" arguments="{hmac: extended.pluginHmac}">RSS</f:link.action>
+		<f:link.action action="list" format="atom" arguments="{hmac: extended.pluginHmac}">Atom</f:link.action>
+		<f:link.action action="list" format="ics" arguments="{hmac: extended.pluginHmac}">iCal</f:link.action>
 	</f:comment>
 
 	<f:render partial="List" arguments="{settings: settings, indices: indices}" />


### PR DESCRIPTION
this add a hash to ics, atom, xml feed links to determine from which action the feed is called
the AbstractController determine on this hash if it call the feedFormat or not
this prevent rendering the search.ics template on list.ics links