### PR TITLE
Fix 'custom search' when start- and end-date is the same date

### DIFF
--- a/Classes/Domain/Repository/IndexRepository.php
+++ b/Classes/Domain/Repository/IndexRepository.php
@@ -135,8 +135,8 @@ class IndexRepository extends AbstractRepository
         $this->addTimeFrameConstraints(
             $constraints,
             $query,
-            $arguments['startDate'] instanceof \DateTimeInterface ? $arguments['startDate']->getTimestamp() : null,
-            $arguments['endDate'] instanceof \DateTimeInterface ? $arguments['endDate']->getTimestamp() : null
+            $startDate instanceof \DateTime ? DateTimeUtility::getDayStart($startDate) : null,
+            $endDate instanceof \DateTime ? DateTimeUtility::getDayEnd($endDate) : null
         );
 
         if ($arguments['indexIds']) {

--- a/Classes/Utility/DateTimeUtility.php
+++ b/Classes/Utility/DateTimeUtility.php
@@ -170,4 +170,31 @@ class DateTimeUtility
         // So we create a date string with timezone information first, and a \DateTime in the current server timezone then.
         return new \DateTime(date(\DateTime::ATOM, (int) $GLOBALS['SIM_ACCESS_TIME']));
     }
+
+    /**
+     * Alias for resetTime.
+     *
+     * @see resetTime()
+     * @param int|null|string|\DateTime $dateInformation
+     *
+     * @return \DateTime
+     */
+    public static function getDayStart($dateInformation)
+    {
+        return self::resetTime($dateInformation);
+    }
+
+    /**
+     * Get the End of the given day.
+     *
+     * @param int|null|string|\DateTime $dateInformation
+     *
+     * @return \DateTime
+     */
+    public static function getDayEnd($dateInformation)
+    {
+        $dateTime = self::getDayStart($dateInformation);
+        $dateTime->setTime(23, 59, 59);
+        return $dateTime;
+    }
 }


### PR DESCRIPTION
Add dayStart and dayEnd to the DateTimeUtility to enable the search with
'TimeFrameConstraints' that can be on the same day.
This may break searches for a distinct TimeInterval on a specific day.