### PR TITLE
fix startTime in addTimeFrameConstraints

### DIFF
--- a/Classes/Domain/Repository/IndexRepository.php
+++ b/Classes/Domain/Repository/IndexRepository.php
@@ -389,7 +389,7 @@ class IndexRepository extends AbstractRepository
     {
         // Simulate start time
         if ($startTime === null) {
-            $startTime = DateTimeUtility::getNow() - DateTimeUtility::SECONDS_DECADE;
+            $startTime = DateTimeUtility::getNow()->getTimestamp() - DateTimeUtility::SECONDS_DECADE;
         }
 
         // Simulate end time


### PR DESCRIPTION
transform the now to timestamp to get a 'real' timestamp that can be substracted by the SECONDS_DECADE