### PR TITLE
fix typo in field name

### DIFF
--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -14,7 +14,7 @@
 				<target>ganztägig</target>
 			</trans-unit>
 			<trans-unit id="mode.single" approved="yes">
-				<source>Sigle</source>
+				<source>Single</source>
 				<target>Einzelansicht</target>
 			</trans-unit>
 

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -395,10 +395,10 @@
 				<source>Special Views</source>
 			</trans-unit>
 			<trans-unit id="mode.single">
-				<source>Sigle</source>
+				<source>Single</source>
 			</trans-unit>
 			<trans-unit id="singleItems">
-				<source>Sigle items</source>
+				<source>Single items</source>
 			</trans-unit>
 
 


### PR DESCRIPTION
fix name for field 'mode.single' and 'singleItems' from sigle to single