### PR TITLE
Introduce event microformat to calendarize

### DIFF
--- a/Classes/ViewHelpers/Link/AbstractLinkViewHelper.php
+++ b/Classes/ViewHelpers/Link/AbstractLinkViewHelper.php
@@ -54,15 +54,17 @@ abstract class AbstractLinkViewHelper extends AbstractTagBasedViewHelper
      *
      * @param int|NULL $pageUid          target page. See TypoLink destination
      * @param array    $additionalParams query parameters to be attached to the resulting URI
+     * @param bool $absolute
      *
      * @return string Rendered page URI
      */
-    public function renderLink($pageUid = null, array $additionalParams = [])
+    public function renderLink($pageUid = null, array $additionalParams = [], $absolute = false)
     {
         $uriBuilder = $this->controllerContext->getUriBuilder();
         $this->lastHref = (string)$uriBuilder->reset()
             ->setTargetPageUid($pageUid)
             ->setArguments($additionalParams)
+            ->setCreateAbsoluteUri($absolute)
             ->build();
         if ($this->lastHref !== '') {
             $this->tag->addAttribute('href', $this->lastHref);

--- a/Classes/ViewHelpers/Link/IndexViewHelper.php
+++ b/Classes/ViewHelpers/Link/IndexViewHelper.php
@@ -22,16 +22,17 @@ class IndexViewHelper extends AbstractLinkViewHelper
      *
      * @param Index $index
      * @param int   $pageUid
+     * @param bool  $absolute
      *
      * @return string
      */
-    public function render(Index $index, $pageUid = null)
+    public function render(Index $index, $pageUid = null, $absolute = false)
     {
         $additionalParams = [
             'tx_calendarize_calendar' => [
                 'index' => $index->getUid()
             ],
         ];
-        return parent::renderLink($this->getPageUid($pageUid, 'detailPid'), $additionalParams);
+        return parent::renderLink($this->getPageUid($pageUid, 'detailPid'), $additionalParams, (bool) $absolute);
     }
 }

--- a/Classes/ViewHelpers/Uri/IndexViewHelper.php
+++ b/Classes/ViewHelpers/Uri/IndexViewHelper.php
@@ -20,12 +20,13 @@ class IndexViewHelper extends \HDNET\Calendarize\ViewHelpers\Link\IndexViewHelpe
      *
      * @param Index $index
      * @param int   $pageUid
+     * @param bool  $absolute
      *
      * @return string
      */
-    public function render(Index $index, $pageUid = null)
+    public function render(Index $index, $pageUid = null, $absolute = false)
     {
-        parent::render($index, $pageUid);
+        parent::render($index, $pageUid, (bool) $absolute);
         return $this->lastHref;
     }
 }

--- a/Resources/Private/Partials/Event/Detail.html
+++ b/Resources/Private/Partials/Event/Detail.html
@@ -48,3 +48,5 @@
 		</f:if>
 	</f:if>
 </f:alias>
+
+<f:render partial="{index.configuration.partialIdentifier}/StructuredData/Detail" arguments="{index: index}"/>

--- a/Resources/Private/Partials/Event/StructuredData/Detail.html
+++ b/Resources/Private/Partials/Event/StructuredData/Detail.html
@@ -1,0 +1,35 @@
+{namespace c=HDNET\Calendarize\ViewHelpers}
+
+<f:comment>
+	StructuredData Markup
+	https://support.google.com/webmasters/answer/3227638?hl=de
+	http://schema.org/Event
+
+	Test Utility
+	https://search.google.com/structured-data/testing-tool
+</f:comment>
+
+<f:alias map="{event: index.originalObject}">
+
+	<script type="application/ld+json">
+		<f:format.raw>{</f:format.raw>
+			"@context": "http://schema.org",
+			"@type": "Event",
+			"name": "{event.title}",
+			"url": "<c:uri.index index="{index}" absolute="true"/>",
+			<f:if condition="{event.images.0}">"image": "<f:uri.page pageUid="{event.images.0.originalResource.publicUrl}" absolute="1"/>",</f:if>
+			<f:if condition="{event.abstract}"><f:then>"description": "{event.abstract}",</f:then>
+							<f:else>"description": "<f:format.crop maxCharacters="180" append=" [...]"><f:format.stripTags>{event.description}</f:format.stripTags></f:format.crop>",</f:else>
+			</f:if>
+			"startDate": "{index.startDateComplete -> f:format.date(format: 'Y-m-d H:i')}",
+			<f:if condition="{index.endTime}"><f:if condition="{index.endTime}!=86399">"endDate": "{index.endDateComplete -> f:format.date(format: 'Y-m-d H:i')}",</f:if></f:if>
+			<f:if condition="{event.location}">
+			<f:format.raw>"location": {</f:format.raw>
+				"@type": "Place",
+				"address": "{event.location}"
+			<f:format.raw>}</f:format.raw>
+			</f:if>
+		<f:format.raw>}</f:format.raw>
+		</script>
+
+</f:alias>


### PR DESCRIPTION
NEW
- enrich the google search result with your event-data
- informations about event-microformat https://support.google.com/webmasters/answer/3227638?hl=en
- based on http://schema.org/Event
- the event data is hold in the JSON-LD markup | alternative you can use the inline html-markup

CHANGE
- add absolute path flag to link.index-ViewHelper and uri.index-ViewHelper to add the domain to the index-links