### PR TITLE
[FEATURE] make amount of items in calendarize_info customizable

### DIFF
--- a/Classes/Register.php
+++ b/Classes/Register.php
@@ -57,6 +57,7 @@ class Register
             'config' => [
                 'type'     => 'user',
                 'userFunc' => TcaInformation::class . '->informationField',
+                'items' => 10
             ],
         ];
         ExtensionManagementUtility::addToAllTCAtypes($tableName, 'calendarize,calendarize_info', $typeList);

--- a/Classes/Service/TcaInformation.php
+++ b/Classes/Service/TcaInformation.php
@@ -34,8 +34,13 @@ class TcaInformation extends AbstractService
         if (!isset($configuration['row']['uid'])) {
             return $this->wrapContent(TranslateUtility::get('save.first'));
         }
-        $indexService = GeneralUtility::makeInstance(IndexerService::class);
+
         $previewLimit = 10;
+        if (isset($configuration['fieldConf']['config']['items'])) {
+            $previewLimit = (int) $configuration['fieldConf']['config']['items'];
+        }
+
+        $indexService = GeneralUtility::makeInstance(IndexerService::class);
         $count = $indexService->getIndexCount($configuration['table'], $configuration['row']['uid']);
         $next = $indexService->getNextEvents($configuration['table'], $configuration['row']['uid'], $previewLimit);
         $content = sprintf(TranslateUtility::get('previewLabel'), $count, $previewLimit) . $this->getEventList($next);

--- a/Documentation/DeveloperManual/OwnEvents/Index.rst
+++ b/Documentation/DeveloperManual/OwnEvents/Index.rst
@@ -30,3 +30,10 @@ The following code show the configuration that should be the same in ext_tables 
         'tableName'         => 'tx_myextension_domain_model_myevent', // the table name of your event table
         'required'          => true, // set to true, than your event need a least one event configuration
     ];
+
+To modify the amount of items shown in the preview you can change the amount in the ext_tables.php after calling the Register::extTables method.
+The default value is 10 items.
+
+.. code-block:: php
+	// in ext_tables.php
+	$GLOBALS['TCA']['tx_myextension_domain_model_myevent']['columns']['calendarize_info']['config']['items'] = 25;


### PR DESCRIPTION
* add items field with default=10 to tca
* change informationField to read the amount
* add documentation