### PR TITLE
Fix TCA groups displayCond in group configurations

### DIFF
--- a/Configuration/TCA/tx_calendarize_domain_model_configuration.php
+++ b/Configuration/TCA/tx_calendarize_domain_model_configuration.php
@@ -189,7 +189,7 @@ $custom = [
                 'size' => 5,
                 'maxitems' => '99',
             ],
-            'displayCond' => 'FIELD:type:=:' . Configuration::TYPE_TIME,
+            'displayCond' => 'FIELD:type:=:' . Configuration::TYPE_GROUP,
         ],
         'frequency' => [
             'config' => [


### PR DESCRIPTION
The `displayCond` for `groups` should be `group` as `group` is the (only) type that uses the `groups` field. Maybe the `displayCond` is therefore unnecessary after all.