### PR TITLE
Fix timezone in complete dates (date and time)

### DIFF
--- a/Classes/Domain/Model/Index.php
+++ b/Classes/Domain/Model/Index.php
@@ -143,7 +143,7 @@ class Index extends AbstractModel
         $date = $this->getStartDate();
         if (!$this->isAllDay() && $date instanceof \DateTimeInterface) {
             $time = DateTimeUtility::normalizeDateTimeSingle($this->getStartTime());
-            $date->setTime($time->format('H'), $time->format('i'), 0);
+            return \DateTime::createFromFormat('Y-m-d H:i', $date->format('Y-m-d') . ' ' . $time->format('H:i'));
         }
 
         return $date;
@@ -159,7 +159,7 @@ class Index extends AbstractModel
         $date = $this->getEndDate();
         if (!$this->isAllDay() && $date instanceof \DateTimeInterface) {
             $time = DateTimeUtility::normalizeDateTimeSingle($this->getEndTime());
-            $date->setTime($time->format('H'), $time->format('i'), 0);
+            return \DateTime::createFromFormat('Y-m-d H:i', $date->format('Y-m-d') . ' ' . $time->format('H:i'));
         }
 
         return $date;


### PR DESCRIPTION
### Change description

Fixes a problem where the resulting DateTime has the timezone of 0am of the day, even though the time (e.g. 10am) is already in another timezone (summer/winter time) by creating a new date instead of modifying the date.

### Example depicting the problem
This is using the Germany/Berlin timezone:

`getStartDate()` `->` `2017-10-29T00:00+02:00` (which is still summer time),
`getStartTime()` `->` `36000` (= 10:00)

`getStartDateComplete()` `->` `2017-10-29T10:00+02:00` (summer time) while it should be with the actual (server) timezone `2017-10-29T10:00+01:00` (winter time). 

The time change is between 2pm and 3pm in the early morning on the 29th of October 2017.

The following day previously already was combined correctly (`2017-10-30T00:00+01:00` `+` `10:00` `=>` `2017-10-30T10:00+01:00`) as the date is well in the new timezone.