### PR TITLE
Workaround configuration sorting

### DIFF
--- a/Classes/Domain/Model/ConfigurationGroup.php
+++ b/Classes/Domain/Model/ConfigurationGroup.php
@@ -4,6 +4,8 @@
  */
 namespace HDNET\Calendarize\Domain\Model;
 
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
 /**
  * Logical configuration group.
  *
@@ -23,7 +25,7 @@ class ConfigurationGroup extends AbstractModel
     /**
      * Configurations.
      *
-     * @var \TYPO3\CMS\Extbase\Persistence\ObjectStorage<\HDNET\Calendarize\Domain\Model\Configuration>
+     * @var string
      * @db text
      */
     protected $configurations;
@@ -59,20 +61,10 @@ class ConfigurationGroup extends AbstractModel
     /**
      * Get configurations.
      *
-     * @return \TYPO3\CMS\Extbase\Persistence\ObjectStorage
+     * @return int[]
      */
-    public function getConfigurations()
+    public function getConfigurationIds()
     {
-        return $this->configurations;
-    }
-
-    /**
-     * Set configurations.
-     *
-     * @param \TYPO3\CMS\Extbase\Persistence\ObjectStorage $configurations
-     */
-    public function setConfigurations($configurations)
-    {
-        $this->configurations = $configurations;
+        return GeneralUtility::intExplode(',', $this->configurations);
     }
 }

--- a/Classes/Service/TimeTable/AbstractTimeTable.php
+++ b/Classes/Service/TimeTable/AbstractTimeTable.php
@@ -43,14 +43,7 @@ abstract class AbstractTimeTable extends AbstractService
      */
     protected function buildSingleTimeTableByGroup(ConfigurationGroup $group)
     {
-        $ids = [];
-        foreach ($group->getConfigurations() as $configuration) {
-            if ($configuration instanceof Configuration) {
-                $ids[] = $configuration->getUid();
-            }
-        }
-
-        return $this->timeTableService->getTimeTablesByConfigurationIds($ids);
+        return $this->timeTableService->getTimeTablesByConfigurationIds($group->getConfigurationIds());
     }
 
     /**


### PR DESCRIPTION
Workaround broken sorting of configurations in configuration groups. The built-in extbase object storage mapper does not respect the order in which the configuration ids are saved in the database, but sorts them by uid which lead to inconclusive results in the calculated time table. This might be related to this bug report: https://forge.typo3.org/issues/27659 (german article: http://blog.teamgeist-medien.de/2014/12/extbase-sortierung-von-child-objects-objectstorages-irre.html)