### PR TITLE
[FEATURE] Add new handling option to make a selection

### DIFF
--- a/Classes/Domain/Model/ConfigurationInterface.php
+++ b/Classes/Domain/Model/ConfigurationInterface.php
@@ -21,6 +21,8 @@ interface ConfigurationInterface
 
     const HANDLING_OVERRIDE = 'override';
 
+    const HANDLING_CUTOUT = 'cutout';
+
     const FREQUENCY_NONE = '';
 
     const FREQUENCY_DAILY = 'daily';

--- a/Classes/Updates/NewIncludeExcludeStructureUpdate.php
+++ b/Classes/Updates/NewIncludeExcludeStructureUpdate.php
@@ -19,7 +19,7 @@ class NewIncludeExcludeStructureUpdate extends AbstractUpdate
      *
      * @var string
      */
-    protected $title = 'Migrate the calendarize configurations to the new include/exclude/override structure';
+    protected $title = 'Migrate the calendarize configurations to the new include/exclude/override/cutout structure';
 
     /**
      * Checks whether updates are required.

--- a/Configuration/TCA/tx_calendarize_domain_model_configuration.php
+++ b/Configuration/TCA/tx_calendarize_domain_model_configuration.php
@@ -103,6 +103,10 @@ $custom = [
                         TranslateUtility::getLll('configuration.handling.' . Configuration::HANDLING_OVERRIDE),
                         Configuration::HANDLING_OVERRIDE,
                     ],
+                    [
+                        TranslateUtility::getLll('configuration.handling.' . Configuration::HANDLING_CUTOUT),
+                        Configuration::HANDLING_CUTOUT,
+                    ],
                 ],
                 'default' => Configuration::HANDLING_INCLUDE,
             ],

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -103,6 +103,9 @@
 			<trans-unit id="configuration.handling.override">
 				<source>Override</source>
 			</trans-unit>
+			<trans-unit id="configuration.handling.cutout">
+				<source>Cut out</source>
+			</trans-unit>
 			<trans-unit id="base_configuration">
 				<source>Base</source>
 			</trans-unit>


### PR DESCRIPTION
Add new handling option to make a selection by times that cuts out only those dates that match the configured times. This is basically the counterpart to "exclude". Just like "exclude", this will not add any new times but changes which are displayed.

An example configuration, describing a special event occuring during an already existing date configuration (e.g. special week during opening hours) would be:
1. (include, group) group of regular opening hours 9am-8pm recurring mo-fr
2. (cutout, time) all-day from 12th to 19th