### PR TITLE
[Feature] Additional plugin option for sorting by end_date

### DIFF
--- a/Classes/Controller/CalendarController.php
+++ b/Classes/Controller/CalendarController.php
@@ -36,7 +36,11 @@ class CalendarController extends AbstractController
         $this->indexRepository->setAdditionalSlotArguments($additionalSlotArguments);
 
         if (isset($this->settings['sorting'])) {
-            $this->indexRepository->setDefaultSortingDirection($this->settings['sorting']);
+            if (isset($this->settings['sortBy'])) {
+                $this->indexRepository->setDefaultSortingDirection($this->settings['sorting'], $this->settings['sortBy']);
+            } else {
+                $this->indexRepository->setDefaultSortingDirection($this->settings['sorting']);
+            }
         }
 
         if (isset($this->arguments['startDate'])) {

--- a/Classes/Domain/Repository/IndexRepository.php
+++ b/Classes/Domain/Repository/IndexRepository.php
@@ -316,10 +316,11 @@ class IndexRepository extends AbstractRepository
      * Set the default sorting direction.
      *
      * @param string $direction
+     * @param string $field
      */
-    public function setDefaultSortingDirection($direction)
+    public function setDefaultSortingDirection($direction, $field = '')
     {
-        $this->defaultOrderings = $this->getSorting($direction);
+        $this->defaultOrderings = $this->getSorting($direction, $field);
     }
 
     /**
@@ -492,14 +493,18 @@ class IndexRepository extends AbstractRepository
      * Get the sorting.
      *
      * @param string $direction
+     * @param string $field
      *
      * @return array
      */
-    protected function getSorting($direction)
+    protected function getSorting($direction, $field = '')
     {
+        if ($field !== 'end') {
+            $field = 'start';
+        }
         return [
-            'start_date' => $direction,
-            'start_time' => $direction,
+            $field.'_date' => $direction,
+            $field.'_time' => $direction,
         ];
     }
 }

--- a/Classes/Domain/Repository/IndexRepository.php
+++ b/Classes/Domain/Repository/IndexRepository.php
@@ -503,8 +503,8 @@ class IndexRepository extends AbstractRepository
             $field = 'start';
         }
         return [
-            $field.'_date' => $direction,
-            $field.'_time' => $direction,
+            $field . '_date' => $direction,
+            $field . '_time' => $direction,
         ];
     }
 }

--- a/Configuration/FlexForms/Calendar.xml
+++ b/Configuration/FlexForms/Calendar.xml
@@ -214,6 +214,26 @@
 					</settings.configuration>
 
 					<!-- Calendar configuration -->
+					<settings.sortBy>
+						<TCEforms>
+							<label>LLL:EXT:calendarize/Resources/Private/Language/locallang.xlf:sortBy</label>
+							<config>
+								<type>select</type>
+								<items>
+									<numIndex index="0">
+										<numIndex index="0">LLL:EXT:calendarize/Resources/Private/Language/locallang.xlf:tx_calendarize_domain_model_configuration.start_date</numIndex>
+										<numIndex index="1">start</numIndex>
+									</numIndex>
+									<numIndex index="1">
+										<numIndex index="0">LLL:EXT:calendarize/Resources/Private/Language/locallang.xlf:tx_calendarize_domain_model_configuration.end_date</numIndex>
+										<numIndex index="1">end</numIndex>
+									</numIndex>
+								</items>
+							</config>
+						</TCEforms>
+					</settings.sortBy>
+
+					<!-- Calendar configuration -->
 					<settings.sorting>
 						<TCEforms>
 							<label>LLL:EXT:calendarize/Resources/Private/Language/locallang.xlf:sorting</label>

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -457,6 +457,10 @@
 				<source>Sorting</source>
 				<target>Sortierung</target>
 			</trans-unit>
+			<trans-unit id="sortBy" approved="yes">
+				<source>Sort by</source>
+				<target>Sortierung nach</target>
+			</trans-unit>
 			<trans-unit id="tca.information" approved="yes">
 				<source>Calendarize (Information - Save to refresh...)</source>
 				<target>Calendarize (Informationen - Speichern um zu aktualisieren...)</target>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -459,6 +459,9 @@
 			<trans-unit id="sorting">
 				<source>Sorting</source>
 			</trans-unit>
+			<trans-unit id="sortBy">
+				<source>Sort by</source>
+			</trans-unit>
 			<trans-unit id="tca.information">
 				<source>Calendarize (Information - Save to refresh...)</source>
 			</trans-unit>


### PR DESCRIPTION
If you want or have to display events with a very long duration, say of some months (e.g. exhibitions), in list view the default sorting by start_date (either ascending or descending) may not be very helpful for users. 

Sorting such events ascending by end_date would present events that will end soon at the top of the list, so users may be more aware that there is a last chance for them to attend soon ending events in case they missed them so far. 

This may be a bit exotic use case but I think that such a sorting is more intuitive for long-term events, so I added an additional optional parameter to the getSorting() function and a corresponding configuration option to the calendar flexform.