### PR TITLE
Followup Fix #197 - Correct time string

### DIFF
--- a/Classes/Service/IndexPreparationService.php
+++ b/Classes/Service/IndexPreparationService.php
@@ -42,12 +42,12 @@ class IndexPreparationService
                 // UTC fix
                 $record['start_date'] = \DateTime::createFromFormat(
                     'Y-m-d H:i:s',
-                    $record['start_date']->format('Y-m-d') . '00:00:00',
+                    $record['start_date']->format('Y-m-d') . ' 00:00:00',
                     new \DateTimeZone('UTC')
                 );
                 $record['end_date'] = \DateTime::createFromFormat(
                     'Y-m-d H:i:s',
-                    $record['end_date']->format('Y-m-d') . '00:00:00',
+                    $record['end_date']->format('Y-m-d') . ' 00:00:00',
                     new \DateTimeZone('UTC')
                 );
 


### PR DESCRIPTION
In 4fe849b37fd92b57f395bed9543cb9bba80f579b I made a tiny mistake: a single space character should precede the time string. `\DateTime::createFromFormat()` can workaround this, but I'm sure it's better to pass the correct data..

Sry for the inconvenience & regards, Christian