### PR TITLE
Move FlexForm labels from EXT:lang into EXT:calendarize

### DIFF
--- a/Configuration/FlexForms/Calendar.xml
+++ b/Configuration/FlexForms/Calendar.xml
@@ -256,7 +256,7 @@
 					<!-- startingpoint -->
 					<persistence.storagePid>
 						<TCEforms>
-							<label>LLL:EXT:lang/locallang_general.xml:LGL.startingpoint</label>
+							<label>LLL:EXT:calendarize/Resources/Private/Language/locallang.xlf:startingpoint</label>
 							<config>
 								<type>group</type>
 								<internal_type>db</internal_type>
@@ -276,7 +276,7 @@
 					<!-- recursive -->
 					<persistence.recursive>
 						<TCEforms>
-							<label>LLL:EXT:lang/locallang_general.xml:LGL.recursive</label>
+							<label>LLL:EXT:calendarize/Resources/Private/Language/locallang.xlf:recursive</label>
 							<config>
 								<type>select</type>
 								<items type="array">

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -449,6 +449,10 @@
 					sind (ignoriert &quot;enable columns&quot;)...
 				</target>
 			</trans-unit>
+			<trans-unit id="recursive" approved="yes">
+				<source>Recursive</source>
+				<target>Rekursiv</target>
+			</trans-unit>
 			<trans-unit id="save.first" approved="yes">
 				<source>Please save the record first...</source>
 				<target>Bite sichere zunächst den Datensatz...</target>
@@ -460,6 +464,10 @@
 			<trans-unit id="sortBy" approved="yes">
 				<source>Sort by</source>
 				<target>Sortierung nach</target>
+			</trans-unit>
+			<trans-unit id="startingpoint" approved="yes">
+				<source>Startingpoint</source>
+				<target>Ausgangspunkt</target>
 			</trans-unit>
 			<trans-unit id="tca.information" approved="yes">
 				<source>Calendarize (Information - Save to refresh...)</source>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -453,6 +453,9 @@
 					(ignore enable columns)...
 				</source>
 			</trans-unit>
+			<trans-unit id="recursive">
+				<source>Recursive</source>
+			</trans-unit>
 			<trans-unit id="save.first">
 				<source>Please save the record first...</source>
 			</trans-unit>
@@ -461,6 +464,9 @@
 			</trans-unit>
 			<trans-unit id="sortBy">
 				<source>Sort by</source>
+			</trans-unit>
+			<trans-unit id="startingpoint">
+				<source>Startingpoint</source>
 			</trans-unit>
 			<trans-unit id="tca.information">
 				<source>Calendarize (Information - Save to refresh...)</source>

--- a/Resources/Private/Language/pl.locallang.xlf
+++ b/Resources/Private/Language/pl.locallang.xlf
@@ -422,6 +422,10 @@
                 <source>There is/are %d item/items in the index of the current record. The next %d events (incl. today) are (ignore enable columns)...</source>
                 <target>Ilość pozycji w indeksie aktualnego rekordu - %d. Kolejne %d wydarzeń (włączając dziś) to (ignoruj &quot;enable columns&quot;)</target>
             </trans-unit>
+            <trans-unit id="recursive" approved="yes">
+                <source>Recursive</source>
+                <target>Rekursywnie</target>
+            </trans-unit>
             <trans-unit id="save.first" approved="yes">
                 <source>Please save the record first...</source>
                 <target>Proszę najpierw zapisać rekord...</target>
@@ -429,6 +433,10 @@
             <trans-unit id="sorting" approved="yes">
                 <source>Sorting</source>
                 <target>Sortowanie</target>
+            </trans-unit>
+            <trans-unit id="startingpoint" approved="yes">
+                <source>Startingpoint</source>
+                <target>Punkt startowy</target>
             </trans-unit>
             <trans-unit id="tca.information" approved="yes">
                 <source>Calendarize (Information - Save to refresh...)</source>


### PR DESCRIPTION
Hello,

Two labels in the plugin FlexForm don't show in TYPO3 v8+ because the language file paths have changed within EXT:lang. This commit moves those labels to calendarize so they show in both v7 and v8 (and presumably v9, but I've only tested in 8.7). I also checked that the PL and DE translations are used correctly in the plugin form.

Thanks!
Paul