### PR TITLE
Fix endtime always zero using import

### DIFF
--- a/Classes/Slots/EventImport.php
+++ b/Classes/Slots/EventImport.php
@@ -89,7 +89,7 @@ class EventImport
 
         $startTime = clone $startDate;
         $configuration->setStartDate(DateTimeUtility::resetTime($startDate));
-        $endTime = $endDate;
+        $endTime = clone $endDate;
         $configuration->setEndDate(DateTimeUtility::resetTime($endDate));
 
         $startTime = DateTimeUtility::getDaySecondsOfDateTime($startTime);


### PR DESCRIPTION
When using the importCommand-function endtime is always saved as zero.
This bug is caused of a missing clone command.