### PR TITLE
FIX #77: Incorrect date time in ics caused by wrong timezone

### DIFF
--- a/Classes/ViewHelpers/DateTime/FormatUtcDateViewHelper.php
+++ b/Classes/ViewHelpers/DateTime/FormatUtcDateViewHelper.php
@@ -25,15 +25,15 @@ class FormatUtcDateViewHelper extends AbstractViewHelper
     public function render(\DateTime $date, string $format = '')
     {
         // save configured timezone
-	    $timezone = date_default_timezone_get();
-	    // set timezone to UTC
-	    date_default_timezone_set("UTC");
+        $timezone = date_default_timezone_get();
+        // set timezone to UTC
+        date_default_timezone_set('UTC');
 
-	    $result = strftime($format, (int) $date->format('U'));
+        $result = strftime($format, (int) $date->format('U'));
 
-	    // restore timezone setting
-	    date_default_timezone_set($timezone);
+        // restore timezone setting
+        date_default_timezone_set($timezone);
 
-	    return $result;
+        return $result;
     }
 }

--- a/Classes/ViewHelpers/DateTime/FormatUtcDateViewHelper.php
+++ b/Classes/ViewHelpers/DateTime/FormatUtcDateViewHelper.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * Provide strftime function in UTC context.
+ */
+declare(strict_types=1);
+
+namespace HDNET\Calendarize\ViewHelpers\DateTime;
+
+use HDNET\Calendarize\ViewHelpers\AbstractViewHelper;
+
+/**
+ * Check if the given Index is on the given day.
+ */
+class FormatUtcDateViewHelper extends AbstractViewHelper
+{
+    /**
+     * Format dateTime using strftime() with UTC timezone
+     *
+     * @param \DateTime $date
+     * @param string     $format
+     *
+     * @return string
+     */
+    public function render(\DateTime $date, string $format = '')
+    {
+        // save configured timezone
+	    $timezone = date_default_timezone_get();
+	    // set timezone to UTC
+	    date_default_timezone_set("UTC");
+
+	    $result = strftime($format, (int) $date->format('U'));
+
+	    // restore timezone setting
+	    date_default_timezone_set($timezone);
+
+	    return $result;
+    }
+}

--- a/Resources/Private/Partials/Feed/Item.ics
+++ b/Resources/Private/Partials/Feed/Item.ics
@@ -1,8 +1,8 @@
-<f:if condition="{index}">BEGIN:VEVENT
+{namespace c=HDNET\Calendarize\ViewHelpers}<f:if condition="{index}">BEGIN:VEVENT
 UID:calendarize-{index.uid}<f:if condition="{index.tstamp}">
 DTSTAMP:<f:format.date format="%Y%m%d">{index.tstamp}</f:format.date></f:if>
-DTSTART:<f:format.date format="{f:if(condition: index.allDay, then: '%Y%m%d', else: '%Y%m%dT%H%M%SZ')}">{index.startDateComplete}</f:format.date>
-DTEND:<f:format.date format="{f:if(condition: index.allDay, then: '%Y%m%d', else: '%Y%m%dT%H%M%SZ')}">{index.endDateComplete}</f:format.date>
+DTSTART:<c:dateTime.formatUtcDate date="{index.startDateComplete}" format="{f:if(condition: index.allDay, then: '%Y%m%d', else: '%Y%m%dT%H%M%SZ')}" />
+DTEND:<c:dateTime.formatUtcDate date="{index.endDateComplete}" format="{f:if(condition: index.allDay, then: '%Y%m%d', else: '%Y%m%dT%H%M%SZ')}" />
 SUMMARY:<f:format.htmlspecialchars>{index.originalObject.feedTitle}</f:format.htmlspecialchars>
 DESCRIPTION:<f:format.htmlspecialchars>{index.originalObject.feedAbstract}</f:format.htmlspecialchars>
 LOCATION:<f:format.htmlspecialchars>{index.originalObject.feedLocation}</f:format.htmlspecialchars>


### PR DESCRIPTION
When exporting events as ics the time is not always formatted using UTC timezone, which leads to wrong calendar entries after import to MS Outlook for example.

When using <f:format.date> in the ics-template Fluid calls the function strftime() which formats the given DateTime according to the default timezone. And the default timezone is only UTC, when it is configured in php.ini or Typo3 [SYS][phpTimeZone] = "UTC".
But most of the time the editors are not going to edit the calendarize start and enddate using UTC timezone. In my use-case PHP is configured to UTC timezone, and Typo3 to "Berlin/Europe" which leads to the timezone "Berlin/Europe" being used in the typo3 context.

So in the ics file the Berlin/Europe time appears and is declared as UTC time, which leads to a time-shift of +2 hours at the moment.

As the problem is related to the fluid DateViewHelper where strftime() is called in context of the default timezone, I would propose to add a ViewHelper where strftime() is always called in context of a UTC timezone setting.

Kind regards
Malte


