### PR TITLE
Fix #214 Column mapping fails for typo3 8.5 and later due to breaking…

### DIFF
--- a/Classes/Register.php
+++ b/Classes/Register.php
@@ -94,7 +94,7 @@ class Register
      *
      * @param array $configuration
      */
-    protected static function createTcaConfiguration(array $configuration)
+    public static function createTcaConfiguration(array $configuration)
     {
         $tableName = $configuration['tableName'];
         $typeList = isset($configuration['tcaTypeList']) ? \trim($configuration['tcaTypeList']) : '';

--- a/Documentation/DeveloperManual/OwnEvents/Index.rst
+++ b/Documentation/DeveloperManual/OwnEvents/Index.rst
@@ -31,6 +31,15 @@ The following code show the configuration that should be the same in ext_tables 
         'required'          => true, // set to true, than your event need a least one event configuration
     ];
 
+Beginning with Typo3 version 8.5 frontend requests no longer load ext_tables.php in requests.
+The only exception is if a backend user is logged in to the backend at the same time to initialize the admin panel or frontend editing.
+In order to load the needed column mapping for your Model, you have to override the tca configuration for the corresponding table:
+
+.. code-block:: php
+
+    // in Configuration/TCA/Overrides/<tx_extension_domain_model_event>.php
+    \HDNET\Calendarize\Register::createTcaConfiguration($configuration));
+
 To modify the amount of items shown in the preview you can change the amount in the ext_tables.php after calling the Register::extTables method.
 The default value is 10 items.
 

--- a/Documentation/DeveloperManual/OwnEvents/Index.rst
+++ b/Documentation/DeveloperManual/OwnEvents/Index.rst
@@ -38,7 +38,7 @@ In order to load the needed column mapping for your Model, you have to override 
 .. code-block:: php
 
     // in Configuration/TCA/Overrides/<tx_extension_domain_model_event>.php
-    \HDNET\Calendarize\Register::createTcaConfiguration($configuration));
+    \HDNET\Calendarize\Register::createTcaConfiguration($configuration);
 
 To modify the amount of items shown in the preview you can change the amount in the ext_tables.php after calling the Register::extTables method.
 The default value is 10 items.


### PR DESCRIPTION
… change #78384 (Frontend ignores TCA in ext_tables.php