### PR TITLE
Added subclasses handling

### DIFF
--- a/Classes/Utility/ExtensionConfigurationUtility.php
+++ b/Classes/Utility/ExtensionConfigurationUtility.php
@@ -50,19 +50,21 @@ class ExtensionConfigurationUtility
     {
         self::loadConfiguration();
 
-        $uniqueRegisterKey = null;
+        $eventClass = \get_class($event);
         foreach (self::$configuration as $configuration) {
-            if ($configuration['modelName'] === \get_class($event)) {
-                $uniqueRegisterKey = $configuration['uniqueRegisterKey'];
-                break;
+            if ($configuration['modelName'] === $eventClass) {
+                return $configuration['uniqueRegisterKey'];
+            }
+            if (isset($configuration['subClasses']) && \is_array($configuration['subClasses'])) {
+                foreach ($configuration['subClasses'] as $subClass) {
+                    if ($subClass === $eventClass) {
+                        return $configuration['uniqueRegisterKey'];
+                    }
+                }
             }
         }
 
-        if (null === $uniqueRegisterKey) {
-            throw new Exception('No valid uniqueRegisterKey for: ' . \get_class($event), 1236712);
-        }
-
-        return $uniqueRegisterKey;
+        throw new Exception('No valid uniqueRegisterKey for: ' . $eventClass, 1236712);
     }
 
     /**

--- a/Documentation/DeveloperManual/OwnEvents/Index.rst
+++ b/Documentation/DeveloperManual/OwnEvents/Index.rst
@@ -29,6 +29,7 @@ The following code show the configuration that should be the same in ext_tables 
         'partialIdentifier' => 'MyEvent', // the identifier of the partials for your event. In most cases this is also unique
         'tableName'         => 'tx_myextension_domain_model_myevent', // the table name of your event table
         'required'          => true, // set to true, than your event need a least one event configuration
+        'subClasses'        => array of classnames, // insert here all classNames, which are used for the extended models
     ];
 
 Beginning with Typo3 version 8.5 frontend requests no longer load ext_tables.php in requests.


### PR DESCRIPTION
For example: Your are using the news extension with individual types with individual model classes. This patch adds the ability to handle these types. You must describe all classes in the configuration:

$configuration = [
        'uniqueRegisterKey' => 'MyEvent', // A unique Key for the register (e.g. you Extension Key + "Event")
        'title'             => 'My Event', // The title for your events (this is shown in the FlexForm configuration of the Plugins)
        'modelName'         => \HDNET\MyExtension\Domain\Model\MyEvent::class, // the name of your model
        'partialIdentifier' => 'MyEvent', // the identifier of the partials for your event. In most cases this is also unique
        'tableName'         => 'tx_myextension_domain_model_myevent', // the table name of your event table
        'required'          => true, // set to true, than your event need a least one event configuration
        'subClasses'        => array of classnames, // insert here all classNames, which are used for the extended models
    ];