### PR TITLE
Use startDate to calculate endDate in search controller

### DIFF
--- a/Classes/Controller/CalendarController.php
+++ b/Classes/Controller/CalendarController.php
@@ -434,8 +434,8 @@ class CalendarController extends AbstractController
             $startDate = clone $baseDate;
         }
         if (!($endDate instanceof \DateTimeInterface)) {
-            $baseDate->modify($this->settings['searchEndModifier']);
-            $endDate = $baseDate;
+            $endDate = clone $startDate;
+            $endDate->modify($this->settings['searchEndModifier']);
         }
 
         $this->slotExtendedAssignMultiple([


### PR DESCRIPTION
If the end date is not set, but the startDate has been set, then it is better to calculate the end date from the variable $startDate.
The variable $startDate is always set, either with the current date or with the given date.