### PR TITLE
[BUGFIX] Missing filtering on uniqueRegisterKey

### DIFF
--- a/Classes/Domain/Repository/IndexRepository.php
+++ b/Classes/Domain/Repository/IndexRepository.php
@@ -295,6 +295,7 @@ class IndexRepository extends AbstractRepository
         $constraints = [];
 
         $constraints[] = $query->equals('foreignUid', $event->getUid());
+        $constraints[] = $query->in('uniqueRegisterKey', $this->indexTypes);
         if (!$future) {
             $constraints[] = $query->lessThanOrEqual('startDate', $now);
         }


### PR DESCRIPTION
For example, if there are records of "news items" and "calenderize events" with the same Uid, the index records from both were merged.