### PR TITLE
Disable the hidden field in TCA for tx_calendarize_domain_model_index

### DIFF
--- a/Configuration/TCA/tx_calendarize_domain_model_index.php
+++ b/Configuration/TCA/tx_calendarize_domain_model_index.php
@@ -15,6 +15,10 @@ $custom = [
         'label_alt' => 'start_date',
         'label_alt_force' => '1',
         'readOnly' => true,
+            'enablecolumns' => [
+            'disabled' => ''
+        ],
+
     ],
     'columns' => [
         'unique_register_key' => [


### PR DESCRIPTION
If the hidden field is enabled for the index table, the indexer service does not update hidden records. Instead of that, it creates new records on each save/reindex process. Thus the limit (300 initiately) does not work and the index table will grow infinitely.