### PR TITLE
[FEATURE] Use Relative Date

### DIFF
--- a/Classes/Hooks/CmsLayout.php
+++ b/Classes/Hooks/CmsLayout.php
@@ -98,13 +98,26 @@ class CmsLayout extends AbstractHook
         if ((bool) $this->flexFormService->get('settings.hidePagination', 'main')) {
             $this->layoutService->addRow(TranslateUtility::get('hide.pagination.teaser'), '!!!');
         }
-        $overrideStartDate = (int) $this->flexFormService->get('settings.overrideStartdate', 'main');
-        if ($overrideStartDate) {
-            $this->layoutService->addRow('OverrideStartdate', \date('d.m.y H:i', $overrideStartDate));
-        }
-        $overrideEndDate = (int) $this->flexFormService->get('settings.overrideEnddate', 'main');
-        if ($overrideEndDate) {
-            $this->layoutService->addRow('OverrideEndDate', \date('d.m.y H:i', $overrideEndDate));
+        $useRelativeDate = (bool) $this->flexFormService->get('settings.useRelativeDate', 'main');
+        if ($useRelativeDate) {
+            $overrideStartRelative = $this->flexFormService->get('settings.overrideStartRelative', 'main');
+            if ($overrideStartRelative) {
+                $this->layoutService->addRow(TranslateUtility::get('override.startrelative'), $overrideStartRelative);
+            }
+            $overrideEndRelative = $this->flexFormService->get('settings.overrideEndRelative', 'main');
+            if ($overrideEndRelative) {
+                $this->layoutService->addRow(TranslateUtility::get('override.endrelative'), $overrideEndRelative);
+            }
+
+        } else {
+            $overrideStartDate = (int) $this->flexFormService->get('settings.overrideStartdate', 'main');
+            if ($overrideStartDate) {
+                $this->layoutService->addRow(TranslateUtility::get('override.startdate'), \date('d.m.y H:i', $overrideStartDate));
+            }
+            $overrideEndDate = (int) $this->flexFormService->get('settings.overrideEnddate', 'main');
+            if ($overrideEndDate) {
+                $this->layoutService->addRow(TranslateUtility::get('override.enddate'), \date('d.m.y H:i', $overrideEndDate));
+            }
         }
 
         $this->addPageIdsToTable();

--- a/Configuration/FlexForms/Calendar.xml
+++ b/Configuration/FlexForms/Calendar.xml
@@ -166,15 +166,26 @@
 							</config>
 						</TCEforms>
 					</settings.hidePagination>
-
+					<settings.useRelativeDate>
+						<TCEforms>
+							<label>LLL:EXT:calendarize/Resources/Private/Language/locallang.xlf:useRelativeDate</label>
+							<onChange>reload</onChange>
+							<config>
+								<type>check</type>
+							</config>
+						</TCEforms>
+					</settings.useRelativeDate>
 					<settings.overrideStartdate>
 						<TCEforms>
 							<label>LLL:EXT:calendarize/Resources/Private/Language/locallang.xlf:override.startdate</label>
 							<displayCond>
-								<OR>
-									<numIndex index="0">FIELD:switchableControllerActions:=:Calendar->list;Calendar->detail</numIndex>
-									<numIndex index="1">FIELD:switchableControllerActions:=:Calendar->list</numIndex>
-								</OR>
+								<AND>
+									<numIndex index="0">FIELD:settings.useRelativeDate:REQ:false</numIndex>
+									<OR>
+										<numIndex index="0">FIELD:switchableControllerActions:=:Calendar->list;Calendar->detail</numIndex>
+										<numIndex index="1">FIELD:switchableControllerActions:=:Calendar->list</numIndex>
+									</OR>
+								</AND>
 							</displayCond>
 							<config>
 								<type>input</type>
@@ -182,15 +193,17 @@
 							</config>
 						</TCEforms>
 					</settings.overrideStartdate>
-
 					<settings.overrideEnddate>
 						<TCEforms>
 							<label>LLL:EXT:calendarize/Resources/Private/Language/locallang.xlf:override.enddate</label>
 							<displayCond>
-								<OR>
-									<numIndex index="0">FIELD:switchableControllerActions:=:Calendar->list;Calendar->detail</numIndex>
-									<numIndex index="1">FIELD:switchableControllerActions:=:Calendar->list</numIndex>
-								</OR>
+								<AND>
+									<numIndex index="0">FIELD:settings.useRelativeDate:REQ:false</numIndex>
+									<OR>
+										<numIndex index="0">FIELD:switchableControllerActions:=:Calendar->list;Calendar->detail</numIndex>
+										<numIndex index="1">FIELD:switchableControllerActions:=:Calendar->list</numIndex>
+									</OR>
+								</AND>
 							</displayCond>
 							<config>
 								<type>input</type>
@@ -198,6 +211,42 @@
 							</config>
 						</TCEforms>
 					</settings.overrideEnddate>
+					<settings.overrideStartRelative>
+						<TCEforms>
+							<label>LLL:EXT:calendarize/Resources/Private/Language/locallang.xlf:override.startrelative</label>
+							<displayCond>
+								<AND>
+									<numIndex index="0">FIELD:settings.useRelativeDate:REQ:true</numIndex>
+									<OR>
+										<numIndex index="0">FIELD:switchableControllerActions:=:Calendar->list;Calendar->detail</numIndex>
+										<numIndex index="1">FIELD:switchableControllerActions:=:Calendar->list</numIndex>
+									</OR>
+								</AND>
+							</displayCond>
+							<config>
+								<type>input</type>
+								<eval>trim</eval>
+							</config>
+						</TCEforms>
+					</settings.overrideStartRelative>
+					<settings.overrideEndRelative>
+						<TCEforms>
+							<label>LLL:EXT:calendarize/Resources/Private/Language/locallang.xlf:override.endrelative</label>
+							<displayCond>
+								<AND>
+									<numIndex index="0">FIELD:settings.useRelativeDate:REQ:true</numIndex>
+									<OR>
+										<numIndex index="0">FIELD:switchableControllerActions:=:Calendar->list;Calendar->detail</numIndex>
+										<numIndex index="1">FIELD:switchableControllerActions:=:Calendar->list</numIndex>
+									</OR>
+								</AND>
+							</displayCond>
+							<config>
+								<type>input</type>
+								<eval>trim</eval>
+							</config>
+						</TCEforms>
+					</settings.overrideEndRelative>
 				</el>
 			</ROOT>
 		</main>

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -325,6 +325,26 @@
 				<source>Hide pagination + Teaser mode</source>
 				<target>Verstecke Pagination + Teaser Modus</target>
 			</trans-unit>
+			<trans-unit id="override.startdate">
+				<source>Override startdate</source>
+				<target>Überschreibe Start-Datum</target>
+			</trans-unit>
+			<trans-unit id="override.enddate">
+				<source>Override enddate</source>
+				<target>Überschreibe End-Datum</target>
+			</trans-unit>
+			<trans-unit id="override.startrelative">
+				<source>Override startdate (relative)</source>
+				<target>Überschreibe Start-Datum (relativ)</target>
+			</trans-unit>
+			<trans-unit id="override.endrelative">
+				<source>Override enddate (relative)</source>
+				<target>Überschreibe End-Datum (relativ)</target>
+			</trans-unit>
+			<trans-unit id="useRelativeDate">
+				<source>Use relative Date ( 'now' or '+1 year')</source>
+				<target>Verwende relative Zeitangabe ( 'now' or '+1 year')</target>
+			</trans-unit>
 			<trans-unit id="inherit" approved="yes">
 				<source>Inherit</source>
 				<target>Vererbt</target>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -352,6 +352,15 @@
 			<trans-unit id="override.enddate">
 				<source>Override enddate</source>
 			</trans-unit>
+			<trans-unit id="override.startrelative">
+				<source>Override startdate (relative)</source>
+			</trans-unit>
+			<trans-unit id="override.endrelative">
+				<source>Override enddate (relative)</source>
+			</trans-unit>
+			<trans-unit id="useRelativeDate">
+				<source>Use relative Date ( 'now' or '+1 year')</source>
+			</trans-unit>
 			<trans-unit id="inherit">
 				<source>Inherit</source>
 			</trans-unit>


### PR DESCRIPTION
You can specify a relative start and end date. For example: "now" and "+1 year".
For example, you can automatically display a list of the next 12 months.

New setting parameter:
settings.useRelativeDate: if settings.useRelativeDate is true, the settings.overrideStartRelative and settings.overrideEndRelative fields are displayed in the plugin settings, and the settings.overrideStartdate and settings.overrideEnddate fields are hidden.