### PR TITLE
[FEATURE] Sort events with end_date to the end of search result

### DIFF
--- a/Classes/Domain/Repository/IndexRepository.php
+++ b/Classes/Domain/Repository/IndexRepository.php
@@ -626,6 +626,13 @@ class IndexRepository extends AbstractRepository
      */
     protected function getSorting($direction, $field = '')
     {
+        if ($field === 'withrangelast') {
+            return [
+                'end_date' => $direction,
+                'start_date' => $direction,
+                'start_time' => $direction,
+            ];
+        }
         if ('end' !== $field) {
             $field = 'start';
         }

--- a/Configuration/FlexForms/Calendar.xml
+++ b/Configuration/FlexForms/Calendar.xml
@@ -288,6 +288,10 @@
 										<numIndex index="0">LLL:EXT:calendarize/Resources/Private/Language/locallang.xlf:tx_calendarize_domain_model_configuration.end_date</numIndex>
 										<numIndex index="1">end</numIndex>
 									</numIndex>
+									<numIndex index="2">
+										<numIndex index="0">LLL:EXT:calendarize/Resources/Private/Language/locallang.xlf:tx_calendarize_domain_model_configuration.with_range_last</numIndex>
+										<numIndex index="1">withrangelast</numIndex>
+									</numIndex>
 								</items>
 							</config>
 						</TCEforms>

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -581,6 +581,10 @@
 				<source>Start date</source>
 				<target>Startdatum</target>
 			</trans-unit>
+			<trans-unit id="tx_calendarize_domain_model_configuration.with_range_last">
+				<source>Start date (Single dates first)</source>
+				<target>Startdatum (Einzeltermin zuerst)</target>
+			</trans-unit>
 			<trans-unit id="tx_calendarize_domain_model_configuration.start_time" approved="yes">
 				<source>Start time</source>
 				<target>Startzeit</target>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -548,6 +548,9 @@
 			<trans-unit id="tx_calendarize_domain_model_configuration.start_date">
 				<source>Start date</source>
 			</trans-unit>
+			<trans-unit id="tx_calendarize_domain_model_configuration.with_range_last">
+				<source>Start date (Single dates first)</source>
+			</trans-unit>
 			<trans-unit id="tx_calendarize_domain_model_configuration.start_time">
 				<source>Start time</source>
 			</trans-unit>


### PR DESCRIPTION
New "sortBy" option "withrangelast" in the plugin settings.

Events with a given end_date and a start_date that is before the start date of the output are always displayed first.
With this sort option, these events are sorted according to the end date and only appear in the list after all events without an end date.
Useful if you want to display more current dates at the beginning of the list. Especially if many events have a start date before the start date of the output and an end date far in the future. Otherwise, these are always displayed at the beginning of the list and you have to browse to see the current events.