### PR TITLE
[BUGFIX] Missing parent::initializeArguments() in AbstractLinkViewHelper

### DIFF
--- a/Classes/ViewHelpers/Link/AbstractLinkViewHelper.php
+++ b/Classes/ViewHelpers/Link/AbstractLinkViewHelper.php
@@ -55,6 +55,7 @@ abstract class AbstractLinkViewHelper extends AbstractTagBasedViewHelper
      */
     public function initializeArguments()
     {
+        parent::initializeArguments();
         $this->registerUniversalTagAttributes();
         $this->registerTagAttribute('target', 'string', 'Target of link', false);
         $this->registerTagAttribute(


### PR DESCRIPTION
The arguments "additionalAttributes" and "data" can now be used.