### PR TITLE
[FEATURE] option to respect index times in constraints resolves #374

### DIFF
--- a/Classes/Domain/Repository/IndexRepository.php
+++ b/Classes/Domain/Repository/IndexRepository.php
@@ -633,12 +633,12 @@ class IndexRepository extends AbstractRepository
         $timezone = new \DateTimeZone('UTC');
 
         // store values for start_date and start_time in separate variables
-        $startDateTime = new \DateTime('@'.$arguments['startTime'], $timezone);
+        $startDateTime = new \DateTime('@' . $arguments['startTime'], $timezone);
         $restrictionLowTime = DateTimeUtility::getDaySecondsOfDateTime($startDateTime);
         $restrictionLowDay = DateTimeUtility::resetTime($startDateTime)->getTimestamp();
 
         // store values for end_date and end_time in separate variables
-        $endDateTime = new \DateTime('@'.$arguments['endTime'], $timezone);
+        $endDateTime = new \DateTime('@' . $arguments['endTime'], $timezone);
         $restrictionHighTime = DateTimeUtility::getDaySecondsOfDateTime($endDateTime);
         $restrictionHighDay = DateTimeUtility::resetTime($endDateTime)->getTimestamp();
 

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -21,3 +21,6 @@ tillDaysRelative =
 
 # cat=basic/int+; type=int+; label=Till Days Past:Maximum of (past) days for which indices should be created (does only make sense if till days relative is enabled). The frequency limit per item is still active, make sure to set the value high enough. It is also possible to leave this blank and set the value per configuration item.
 tillDaysPast =
+
+# cat=basic/enable; type=boolean; label=Respect times in time frame constraints: Per default IndexRepository->addTimeFrameConstraints() only checks start_date and end_date. If you want the actual times to be respected (e.g. if settings.overrideStartRelative is set to 'now') enable this option.
+respectTimesInTimeFrameConstraints = 0


### PR DESCRIPTION
Thanks to @svwerder for helping with this.

This pull request adds the option `respectTimesInTimeFrameConstraints` to the extension configuration.
The option is disabled by default, so nothing changes for existing installations.
If enabled `IndexRepository->addTimeFrameConstraints()` adds constraints which also respect the `start_time` and `end_time` of the indices.