### PR TITLE
[BUGFIX] Fix version constraint of typo3 in ext_emconf.php

### DIFF
--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -14,7 +14,7 @@ $EM_CONF[$_EXTKEY] = [
     'author_email' => 'tim@fruit-lab.de',
     'constraints' => [
         'depends' => [
-            'typo3' => '10.4.0-10.4-99',
+            'typo3' => '10.4.0-10.4.99',
             'php' => '7.2.0-7.4.99',
             'autoloader' => '7.0.0',
         ],


### PR DESCRIPTION
I've noticed this while running migration wizards via CLI (using ext:typo3_console).