### PR TITLE
[BUGFIX] Return correct identifier in update wizards (class name)

### DIFF
--- a/Classes/Updates/CalMigrationUpdate.php
+++ b/Classes/Updates/CalMigrationUpdate.php
@@ -1057,7 +1057,7 @@ class CalMigrationUpdate implements UpgradeWizardInterface
 
     public function getIdentifier(): string
     {
-        return 'calendarizeCalMigrationUpdate';
+        return self::class;
     }
 
     public function getTitle(): string

--- a/Classes/Updates/NewIncludeExcludeStructureUpdate.php
+++ b/Classes/Updates/NewIncludeExcludeStructureUpdate.php
@@ -125,7 +125,7 @@ class NewIncludeExcludeStructureUpdate implements UpgradeWizardInterface
 
     public function getIdentifier(): string
     {
-        return 'calendarizeNewIncludeExcludeStructureUpdate';
+        return self::class;
     }
 
     public function getTitle(): string


### PR DESCRIPTION
Without this patch method `assertIdentifierIsValid` in `TYPO3\CMS\Install\Service\UpgradeWizardsService` throws an error, because the class name is [used as identifier](https://github.com/lochmueller/calendarize/blob/master/ext_localconf.php#L50-L51).