### PR TITLE
[BUGFIX] Add missing renderType to flexform 'Calendar.xml'

### DIFF
--- a/Configuration/FlexForms/Calendar.xml
+++ b/Configuration/FlexForms/Calendar.xml
@@ -19,6 +19,7 @@
 							<onChange>reload</onChange>
 							<config>
 								<type>select</type>
+								<renderType>selectSingle</renderType>
 								<items>
 									<numIndex index="0">
 										<numIndex index="0">LLL:EXT:calendarize/Resources/Private/Language/locallang.xlf:mode.normal</numIndex>
@@ -266,7 +267,7 @@
 							<config>
 								<type>select</type>
 								<itemsProcFunc>HDNET\Calendarize\Service\PluginConfigurationService->addConfig</itemsProcFunc>
-								<renderMode>checkbox</renderMode>
+								<renderType>selectCheckBox</renderType>
 								<minitems>1</minitems>
 								<maxitems>99</maxitems>
 							</config>
@@ -279,6 +280,7 @@
 							<label>LLL:EXT:calendarize/Resources/Private/Language/locallang.xlf:sortBy</label>
 							<config>
 								<type>select</type>
+								<renderType>selectSingle</renderType>
 								<items>
 									<numIndex index="0">
 										<numIndex index="0">LLL:EXT:calendarize/Resources/Private/Language/locallang.xlf:tx_calendarize_domain_model_configuration.start_date</numIndex>
@@ -303,6 +305,7 @@
 							<label>LLL:EXT:calendarize/Resources/Private/Language/locallang.xlf:sorting</label>
 							<config>
 								<type>select</type>
+								<renderType>selectSingle</renderType>
 								<items>
 									<numIndex index="0">
 										<numIndex index="0">ASC</numIndex>
@@ -338,6 +341,7 @@
 							<label>LLL:EXT:calendarize/Resources/Private/Language/locallang.xlf:recursive</label>
 							<config>
 								<type>select</type>
+								<renderType>selectSingle</renderType>
 								<items type="array">
 									<numIndex index="1" type="array">
 										<numIndex index="0">LLL:EXT:calendarize/Resources/Private/Language/locallang.xlf:inherit</numIndex>


### PR DESCRIPTION
The core TCA auto migrations where removed in v10 (https://review.typo3.org/c/Packages/TYPO3.CMS/+/59445/).