### PR TITLE
[BUGFIX] fix @Hook annotations for the current EXT:autoloader master

### DIFF
--- a/Classes/Hooks/CmsLayout.php
+++ b/Classes/Hooks/CmsLayout.php
@@ -44,7 +44,7 @@ class CmsLayout extends AbstractHook
      * @param array $params Parameters to the hook
      *
      * @return string Information about pi1 plugin
-     * @Hook TYPO3_CONF_VARS|SC_OPTIONS|cms/layout/class.tx_cms_layout.php|list_type_Info|calendarize_calendar
+     * @Hook("TYPO3_CONF_VARS|SC_OPTIONS|cms/layout/class.tx_cms_layout.php|list_type_Info|calendarize_calendar")
      */
     public function getExtensionSummary(array $params)
     {

--- a/Classes/Hooks/KeSearchIndexer.php
+++ b/Classes/Hooks/KeSearchIndexer.php
@@ -18,8 +18,8 @@ use TYPO3\CMS\Extbase\Object\ObjectManager;
 /**
  * KE Search Indexer.
  *
- * @Hook TYPO3_CONF_VARS|EXTCONF|ke_search|registerIndexerConfiguration
- * @Hook TYPO3_CONF_VARS|EXTCONF|ke_search|customIndexer
+ * @Hook("TYPO3_CONF_VARS|EXTCONF|ke_search|registerIndexerConfiguration")
+ * @Hook("TYPO3_CONF_VARS|EXTCONF|ke_search|customIndexer")
  */
 class KeSearchIndexer extends AbstractHook
 {

--- a/Classes/Hooks/ProcessCmdmapClass.php
+++ b/Classes/Hooks/ProcessCmdmapClass.php
@@ -16,7 +16,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 /**
  * Hook for cmd map processing.
  *
- * @Hook TYPO3_CONF_VARS|SC_OPTIONS|t3lib/class.t3lib_tcemain.php|processCmdmapClass
+ * @Hook("TYPO3_CONF_VARS|SC_OPTIONS|t3lib/class.t3lib_tcemain.php|processCmdmapClass")
  */
 class ProcessCmdmapClass extends AbstractHook
 {

--- a/Classes/Hooks/ProcessDatamapClass.php
+++ b/Classes/Hooks/ProcessDatamapClass.php
@@ -16,7 +16,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 /**
  * Hook for data map processing.
  *
- * @Hook   TYPO3_CONF_VARS|SC_OPTIONS|t3lib/class.t3lib_tcemain.php|processDatamapClass
+ * @Hook("TYPO3_CONF_VARS|SC_OPTIONS|t3lib/class.t3lib_tcemain.php|processDatamapClass")
  */
 class ProcessDatamapClass extends AbstractHook
 {

--- a/Classes/Hooks/RealurlConfiguration.php
+++ b/Classes/Hooks/RealurlConfiguration.php
@@ -22,7 +22,7 @@ class RealurlConfiguration extends AbstractHook
      * @param $pObj
      *
      * @return array
-     * @Hook TYPO3_CONF_VARS|SC_OPTIONS|ext/realurl/class.tx_realurl_autoconfgen.php|extensionConfiguration
+     * @Hook("TYPO3_CONF_VARS|SC_OPTIONS|ext/realurl/class.tx_realurl_autoconfgen.php|extensionConfiguration")
      */
     public function addCalendarizeConfiguration($params, &$pObj)
     {

--- a/Classes/Hooks/TimeShift.php
+++ b/Classes/Hooks/TimeShift.php
@@ -20,7 +20,7 @@ class TimeShift extends AbstractHook
     /**
      * Shift the time variables.
      *
-     * @Hook TYPO3_CONF_VARS|SC_OPTIONS|tslib/index_ts.php|preprocessRequest
+     * @Hook("TYPO3_CONF_VARS|SC_OPTIONS|tslib/index_ts.php|preprocessRequest")
      */
     public function shift()
     {


### PR DESCRIPTION
I am currently trying to make the current master of EXT:calendarize work in TYPO3 10.
I noticed that when using EXT:calendarize together with the current master of EXT:autoloader no hooks of EXT:calendarize are registered. This pull request fixes the issue.