### PR TITLE
[TASK] Check only null for overridePageIds

### DIFF
--- a/Classes/Domain/Repository/IndexRepository.php
+++ b/Classes/Domain/Repository/IndexRepository.php
@@ -47,7 +47,7 @@ class IndexRepository extends AbstractRepository
      *
      * @var array
      */
-    protected $overridePageIds = [];
+    protected $overridePageIds;
 
     /**
      * Create query.
@@ -530,7 +530,7 @@ class IndexRepository extends AbstractRepository
      */
     protected function getStoragePageIds()
     {
-        if (!empty($this->overridePageIds)) {
+        if ($this->overridePageIds !== null) {
             return $this->overridePageIds;
         }
 


### PR DESCRIPTION
By changing the default value to null and checking for null instead of
an array it is possible to use
in a custom code to remove the pid constraint