### PR TITLE
Replace EXT:microformat with EXT:schema

### DIFF
--- a/Resources/Private/Partials/Event/Detail.html
+++ b/Resources/Private/Partials/Event/Detail.html
@@ -57,6 +57,6 @@
 	</f:if>
 </f:alias>
 
-<c:ifExtensionLoaded extensionKey="microformat">
+<c:ifExtensionLoaded extensionKey="schema">
 	<f:render partial="{index.configuration.partialIdentifier}/StructuredData/Detail" arguments="{index: index}"/>
 </c:ifExtensionLoaded>

--- a/Resources/Private/Partials/Event/StructuredData/Detail.html
+++ b/Resources/Private/Partials/Event/StructuredData/Detail.html
@@ -1,38 +1,42 @@
-{namespace c=HDNET\Calendarize\ViewHelpers}
-{namespace m=HDNET\Microformat\ViewHelpers}
-
+<html
+	xmlns:f="https://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
+	xmlns:schema="http://typo3.org/ns/Brotkrueml/Schema/ViewHelpers"
+	schema:schemaLocation="https://brot.krue.ml/schemas/schema-1.9.0.xsd"
+	xmlns:c="http://typo3.org/ns/HDNET/Calendarize/ViewHelpers"
+	data-namespace-typo3-fluid="true"
+>
 <f:comment>
-	EXT:microformat
-
 	StructuredData Markup
-	https://support.google.com/webmasters/answer/3227638?hl=de
+	https://developers.google.com/search/docs/data-types/event
 	http://schema.org/Event
 
 	Test Utility
 	https://search.google.com/structured-data/testing-tool
+	https://search.google.com/test/rich-results
 </f:comment>
 
 <f:alias map="{event: index.originalObject}">
-<m:format.jsonLd showInHead="1" jsonPrettyPrint="0">
-	<m:microformat.event
-		name="{event.title}"
-		description="{f:render(section: 'EventDescription', arguments: {event: event})}"
-		url='<c:uri.index index="{index}" absolute="true"/>'
-		startDate='{index.startDateComplete -> f:format.date(format: "Y-m-d H:i")}'
-		endDate='{index.endDateComplete -> f:format.date(format: "Y-m-d H:i")}'
-	>
-
-		<f:if condition="{event.images.0}">
-			<m:microformat.imageObject key="image" caption="{event.images.0.originalResource.title}" url='{f:uri.page(pageUid: "{event.images.0.originalResource.publicUrl}", absolute: 1)}'></m:microformat.imageObject>
-		</f:if>
-		<f:if condition="{event.location}">
-				<m:microformat.Place key="location" name="{event.location}" />
-		</f:if>
-		<f:if condition="{event.organizer}">
-				<m:microformat.Organization key="organizer" name="{event.organizer}" />
-		</f:if>
-	</m:microformat.event>
-</m:format.jsonLd>
+<schema:type.event
+	-isMainEntityOfWebPage="1"
+	name="{event.title}"
+	description="{f:render(section: 'EventDescription', arguments: {event: event})}"
+	url='<c:uri.index index="{index}" absolute="true"/>'
+	startDate='{index.startDateComplete -> f:format.date(format: "c")}'
+	endDate='{index.endDateComplete -> f:format.date(format: "c")}'
+>
+	<f:if condition="{index.state}=='canceled'">
+		<schema:property -as="eventStatus" value="EventCancelled" />
+	</f:if>
+	<f:if condition="{event.images.0}">
+		<schema:type.imageObject -as="image" caption="{event.images.0.originalResource.title}" url="{f:uri.image(image: '{event.images.0}', absolute: 1)}" />
+	</f:if>
+	<f:if condition="{event.location}">
+		<schema:property -as="location" value="{event.location}" />
+	</f:if>
+	<f:if condition="{event.organizer}">
+		<schema:type.organization -as="organizer" name="{event.organizer}" url="{event.organizerLink}"/>
+	</f:if>
+</schema:type.event>
 </f:alias>
 
 
@@ -42,9 +46,10 @@
 	The EventDescription is the abstract or a part of the description.
 	To build a condition-block for the viewHelper-attribute, the outsourcing in sections comes handy.
 </f:comment>
-<f:section name="EventDescription"><m:format.trim>
+<f:section name="EventDescription">
 	<f:if condition="{event.abstract}">
 		<f:then>{event.abstract}</f:then>
 		<f:else><f:format.crop maxCharacters="180" append=" [...]"><f:format.stripTags>{event.description}</f:format.stripTags></f:format.crop></f:else>
 	</f:if>
-</m:format.trim></f:section>
+</f:section>
+</html>

--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
 		"issues": "https://github.com/lochmueller/calendarize/issues"
 	},
 	"suggest": {
-		"cabi/microformat": "Output of microformat information for better Google Search Result User Experience"
+		"brotkrueml/schema": "Output of structured data information for better Google Search Result User Experience"
 	},
 	"require-dev": {
 		"namelesscoder/typo3-repository-client": "^2.0",


### PR DESCRIPTION
## Feature
Replaces outdated [microformat](https://github.com/cabi/microformat) with [schema](https://github.com/brotkrueml/schema).
- [brotkrueml/schema](https://github.com/brotkrueml/schema).
  - Provides Fluid and PHP API
  - Seems to be actively supported

## Example output (prettified)
_Note_: Google test tool throws an error on URL, because `localhost` is not publicly accessibil!
```json
{
  "@context":"http://schema.org",
  "@type":"WebPage",
  "mainEntity":{
    "@type":"Event",
    "description":"\n\tAn event for to test calendarize!\n",
    "endDate":"2020-10-08T18:18:00+00:00",
    "eventStatus":"EventCancelled",
    "image":{
      "@type":"ImageObject",
      "caption":"ImageTitle",
      "url":"http://localhost/fileadmin/user_upload/test.jpg"
    },
    "location":"Somewhere in the world.",
    "name":"TestEvent",
    "organizer":{
      "@type":"Organization",
      "name":"MyOrganisation",
      "url":"http://orga.example"
    },
    "startDate":"2020-10-04T08:08:00+00:00",
    "url":"http://localhost/autogenerated-2/?tx_calendarize_calendar%5Bindex%5D=5&cHash=b3848526146cf6268389d0a289e5591a"
  }
}
```

## Notes
- Can have `\n\t` or similar in description text
- Always outputs full timestamp `2020-10-26T02:00:00+00:00`
  - ignoring 'all_day' -> better to display only the date
- missing `address` from location (error from google testing tool)
  - is valid after schema.org spec, because `Text` is allowed for property `location`

## Test environment
- Typo3 10.4.9
- PHP 7.4.10
- calendarize 7.0.0 (modified)
- schema 1.9.0

## Similar extensions
- [codingms/schema_org](https://bitbucket.org/codingms/schema_org)
  - only typoscript for static information (opening hours, etc.)
- [cabi/microformat](https://github.com/cabi/microformat)
  - outdated
- [georgringer/schema_org_generator](https://github.com/georgringer/schema_org_generator)
  - only PoC
