### PR TITLE
Fix documentation on docs.typo3.org

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 /.idea/
 /.Build/*
 /.php_cs.cache
+
+# ignore generated documentation
+*GENERATED*

--- a/Documentation/AdministratorManual/Configuration/Index.rst
+++ b/Documentation/AdministratorManual/Configuration/Index.rst
@@ -8,21 +8,23 @@ Via the constant editor, you can adapt template path and feed options. There are
 The last step is, place the plugins on your pages. The view is always related to the configured PIDs. That means, if you create a month view and set a detailPid, the template will render detail links to events.
 If you leave the detailPid empty and select the monthPid, no events are in the output and the month view is a "small month view". Just try same combinations :)
 
-For a easy editor workflow you can active the time selection wizard by the given Page TS Config.::
+For a easy editor workflow you can active the time selection wizard by the given Page TS Config.:
 
-           tx_calendarize.timeSelectionWizard {
-             1 = 9:00
-             2 = 12:00
-             3 = 18:00
-             4 = 20:15
-           }
+.. code-block:: typoscript
+
+  tx_calendarize.timeSelectionWizard {
+    1 = 9:00
+    2 = 12:00
+    3 = 18:00
+    4 = 20:15
+  }
 
 
 
 XML Sitemap for TYPO3 > 9.0
 ---------------------------
 
-.. code-block::
+.. code-block:: typoscript
 
   plugin.tx_seo {
     config {
@@ -51,6 +53,8 @@ Breadcrumb menu
 ---------------
 
 To add the calendarize link to the breadcrumb use this user function
+
+.. code-block:: typoscript
 
   [globalVar = GP:tx_calendarize_calendar|index > 0]
   # [request.getQueryParams()['tx_calendarize_calendar']['index'] > 0] # TYPO3 >= 9

--- a/Documentation/Includes.txt
+++ b/Documentation/Includes.txt
@@ -11,11 +11,25 @@ every ReST source file in this documentation project (= manual).
 .. DEFINE SOME TEXT ROLES
 .. --------------------------------------------------
 
-.. role::   typoscript(code)
+.. role:: aspect (emphasis)
+.. role:: html(code)
+.. role:: js(code)
+.. role:: php(code)
+.. role:: rst(code)
+.. role:: sep (strong)
+.. role:: typoscript(code)
 
-.. role::   ts(typoscript)
-:class:  typoscript
+.. role:: ts(typoscript)
+   :class: typoscript
 
-.. role::   php(code)
+.. role:: yaml(code)
+
+.. default-role:: code
+
+.. ---------
+.. highlight
+.. ---------
+
+.. By default, code blocks are php
 
 .. highlight:: php

--- a/Documentation/Settings.cfg
+++ b/Documentation/Settings.cfg
@@ -1,0 +1,17 @@
+# coding: utf-8
+
+[general]
+project = Calendarize
+release = 7.0.0
+copyright = 2014-2020 Tim Lochmüller
+
+
+[html_theme_options]
+github_branch = master
+github_repository = lochmueller/calendarize
+
+project_contact = tim@fruit-lab.de
+project_discussions =
+project_home = https://github.com/lochmueller/calendarize
+project_issues = https://github.com/lochmueller/calendarize/issues
+project_repository = https://github.com/lochmueller/calendarize

--- a/Documentation/Snippets/Index.rst
+++ b/Documentation/Snippets/Index.rst
@@ -1,7 +1,9 @@
 Snippets
 ========
 
-Get the event title of the current page (e.g. for Breadcrumb navigations)::
+Get the event title of the current page (e.g. for Breadcrumb navigations):
+
+.. code-block:: typoscript
 
   lib.eventTitle = CONTENT
   lib.eventTitle {

--- a/Documentation/Templates/Changing/Index.rst
+++ b/Documentation/Templates/Changing/Index.rst
@@ -14,7 +14,9 @@ Changing paths of the template
 Please do never change templates directly in the resources folder of the extensions,
 since your changes will get overwritten by extension updates.
 
-Configure your TypoScript setup like shown below::
+Configure your TypoScript setup like shown below:
+
+.. code-block:: typoscript
 
   plugin.tx_calendarize {
     view {
@@ -31,7 +33,9 @@ Configure your TypoScript setup like shown below::
   }
 
 Doing so, you can just **override single files** from the original templates.
-The calendarize templates are always the fallback (position 50). Alternatively you can change the constants::
+The calendarize templates are always the fallback (position 50). Alternatively you can change the constants:
+
+.. code-block:: typoscript
 
   plugin.tx_calendarize.view.templateRootPath
   plugin.tx_calendarize.view.partialRootPath


### PR DESCRIPTION
Fix #401


## Steps to have the extension documentation on docs.typo3.org 
To have docs online avaiable, you have to [Register for docs.typo3.org](https://docs.typo3.org/m/typo3/docs-how-to-document/master/en-us/WritingDocForExtension/Migrate.html#migrate)
Missing steps:

- [X] Add Documentation/Settings.cfg (see first commit)
- [x] Add a new webhook, see [here](https://docs.typo3.org/m/typo3/docs-how-to-document/master/en-us/WritingDocForExtension/Webhook.html#webhook-github)
- [ ] (Optional) Trigger webhook for released versions, see [here](https://docs.typo3.org/m/typo3/docs-how-to-document/master/en-us/WritingDocForExtension/ReregisterVersions.html#reregister-versions). This may not work, because the `Settings.cfg` would be missing in the older versions.

I proposed a `Settings.cfg` with the mandentory information. You may want to change them.
Since I found not any crossreferences, I did not add the `[intersphinx_mapping]` part.

This propaly also applys to some other typo3 extensions managed by @lochmueller.

The second commit fixes and updates the includes.txt an adds some code block formatting.
It also add an `*GENERATED*` to the gitignore, so it does not add the [locally rendered documentation](https://docs.typo3.org/m/typo3/docs-how-to-document/master/en-us/RenderingDocs/Quickstart.html#render-documenation-with-docker) to the versioning system.
