### PR TITLE
Add configuration variables for field positioning on custom elements

### DIFF
--- a/Classes/Register.php
+++ b/Classes/Register.php
@@ -116,12 +116,8 @@ class Register
         $tableName = $configuration['tableName'];
         $typeList = isset($configuration['tcaTypeList']) ? \trim($configuration['tcaTypeList']) : '';
         // Configure position of where to put the calendarize fields
-        // Either after a field or before a field; after takes precedence, if defined
-        // Parameter value is the single TCA field name
-        $position = isset($configuration['addColumnsAfter']) ? 'after:' . \trim($configuration['addColumnsAfter']): '';
-        if (!$position && isset($configuration['addColumnsBefore'])) {
-            $position = 'before:' . \trim($configuration['addColumnsBefore']);
-        }
+        // Supports everything offered by TYPO3, e.g.: before:abc, after:abc, replace:abc
+        $position = isset($configuration['tcaPosition']) ? \trim($configuration['tcaPosition']): '';
         $GLOBALS['TCA'][$tableName]['columns'][$fieldName] = [
             'label' => 'Calendarize',
             'l10n_mode' => 'exclude',

--- a/Classes/Register.php
+++ b/Classes/Register.php
@@ -115,6 +115,13 @@ class Register
         $fieldName = isset($configuration['fieldName']) ? $configuration['fieldName'] : 'calendarize';
         $tableName = $configuration['tableName'];
         $typeList = isset($configuration['tcaTypeList']) ? \trim($configuration['tcaTypeList']) : '';
+        // Configure position of where to put the calendarize fields
+        // Either after a field or before a field; after takes precedence, if defined
+        // Parameter value is the single TCA field name
+        $position = isset($configuration['addColumnsAfter']) ? 'after:' . \trim($configuration['addColumnsAfter']): '';
+        if ( !$position && isset($configuration['addColumnsBefore']) ) {
+            $position = 'before:'. \trim($configuration['addColumnsBefore']);
+        }
         $GLOBALS['TCA'][$tableName]['columns'][$fieldName] = [
             'label' => 'Calendarize',
             'l10n_mode' => 'exclude',
@@ -139,7 +146,7 @@ class Register
                 ],
             ],
         ];
-        ExtensionManagementUtility::addToAllTCAtypes($tableName, $fieldName . ',calendarize_info', $typeList);
+        ExtensionManagementUtility::addToAllTCAtypes($tableName, $fieldName . ',calendarize_info', $typeList, $position);
     }
 
     /**

--- a/Classes/Register.php
+++ b/Classes/Register.php
@@ -119,7 +119,7 @@ class Register
         // Either after a field or before a field; after takes precedence, if defined
         // Parameter value is the single TCA field name
         $position = isset($configuration['addColumnsAfter']) ? 'after:' . \trim($configuration['addColumnsAfter']): '';
-        if ( !$position && isset($configuration['addColumnsBefore']) ) {
+        if (!$position && isset($configuration['addColumnsBefore'])) {
             $position = 'before:' . \trim($configuration['addColumnsBefore']);
         }
         $GLOBALS['TCA'][$tableName]['columns'][$fieldName] = [

--- a/Classes/Register.php
+++ b/Classes/Register.php
@@ -120,7 +120,7 @@ class Register
         // Parameter value is the single TCA field name
         $position = isset($configuration['addColumnsAfter']) ? 'after:' . \trim($configuration['addColumnsAfter']): '';
         if ( !$position && isset($configuration['addColumnsBefore']) ) {
-            $position = 'before:'. \trim($configuration['addColumnsBefore']);
+            $position = 'before:' . \trim($configuration['addColumnsBefore']);
         }
         $GLOBALS['TCA'][$tableName]['columns'][$fieldName] = [
             'label' => 'Calendarize',


### PR DESCRIPTION
The position can be set either before or after a specified field name. This prevents it from being on the last tab after the last field.
It can even be put directly behind a tab divider if you use the third example.

This was tested on release Version 7.1.0 with our own plugin using all of the examples below. I expected a tab to appear when adding my objects to the extension. Since only the fields came, I chose to rather add a configurable position for the fields instead.

Examples for the Register::extTables() configuration:
1. 'addColumnsAfter' => 'images'
The two fields (calendarize, calendarize_info) are put right after the field "images".

2. 'addColumnsBefore' => 'location'
Just before "location", the two fields will appear.

3. 'addColumnsAfter' => '--div--;LLL:EXT:custom_calendarize_events/Resources/Private/Language/locallang_db.xlf:tabs.timetable'
The first items on the tab "timetable" will be the two fields.