### PR TITLE
Add multiple table filters (and a minor bugfix)

### DIFF
--- a/Classes/Domain/Repository/IndexRepository.php
+++ b/Classes/Domain/Repository/IndexRepository.php
@@ -222,16 +222,16 @@ class IndexRepository extends AbstractRepository
             $foreignIdConstraints = [];
             // Old way, just accept foreignUids as provided, not checking the table.
             // This has a caveat solved with the $tabledIndexIds
-            if ( $indexIds ) {
+            if ($indexIds) {
                 $foreignIdConstraints[] = $query->in('foreignUid', $indexIds);
             }
-            if ( $tabledIndexIds ) {
+            if ($tabledIndexIds) {
                 // Handle each table individually on the filters
                 // allowing for uids to be table specific.
                 // If 1,3,5 on table_a are ok and 4,5,7 on table_b are ok,
                 // don't show uid 1 from table_b
-                foreach ( $tabledIndexIds as $tabledIndexId ) {
-                    if ( $tabledIndexId['indexIds'] ) {
+                foreach ($tabledIndexIds as $tabledIndexId) {
+                    if ($tabledIndexId['indexIds']) {
                         // This table has used filters and returned some allowed uids.
                         // Providing non-existing values e.g.: -1 will remove everything
                         // unless other elements have found elements with the filters
@@ -242,7 +242,7 @@ class IndexRepository extends AbstractRepository
                     }
                 }
             }
-            if ( count($foreignIdConstraints) > 1 ) {
+            if (count($foreignIdConstraints) > 1) {
                 // Multiple valid tables should be grouped by "OR"
                 // so it's either table_a with uids 1,3,4 OR table_b with uids 1,5,7
                 $foreignIdConstraint = $query->logicalOr($foreignIdConstraints);
@@ -251,7 +251,7 @@ class IndexRepository extends AbstractRepository
                 $foreignIdConstraint = array_shift($foreignIdConstraints);
             }
             // If any foreignUid constraint survived, use it on the query
-            if ( $foreignIdConstraint ) {
+            if ($foreignIdConstraint) {
                 $constraints[] = $foreignIdConstraint;
             }
         }
@@ -631,7 +631,7 @@ class IndexRepository extends AbstractRepository
         $arguments = $this->callSignal(__CLASS__, __FUNCTION__, $arguments);
 
         if ($arguments['indexIds']) {
-            $constraints[] = $query->in('foreign_uid', $arguments['indexIds']);
+            $constraints[] = $query->in('foreignUid', $arguments['indexIds']);
         }
 
         return $constraints;
@@ -703,25 +703,25 @@ class IndexRepository extends AbstractRepository
             // (end_date === restrictionLowDay && end_time >= restrictionLowTime) || end_date > restrictionLowDay || (all_day === true && end_date >= restrictionLowDay)
             $query->logicalOr([
                 $query->logicalAnd([
-                    $query->equals('end_date', $restrictionLowDay),
-                    $query->greaterThanOrEqual('end_time', $restrictionLowTime),
+                    $query->equals('endDate', $restrictionLowDay),
+                    $query->greaterThanOrEqual('endTime', $restrictionLowTime),
                 ]),
-                $query->greaterThan('end_date', $restrictionLowDay),
+                $query->greaterThan('endDate', $restrictionLowDay),
                 $query->logicalAnd([
-                    $query->equals('all_day', true),
-                    $query->greaterThanOrEqual('end_date', $restrictionLowDay),
+                    $query->equals('allDay', true),
+                    $query->greaterThanOrEqual('endDate', $restrictionLowDay),
                 ]),
             ]),
             // (start_date === restrictionHighDay && start_time <= restrictionHighTime) || start_date < restrictionHighDay || (all_day === true && start_date <= restrictionHighDay)
             $query->logicalOr([
                 $query->logicalAnd([
-                    $query->equals('start_date', $restrictionHighDay),
-                    $query->lessThanOrEqual('start_time', $restrictionHighTime),
+                    $query->equals('startDate', $restrictionHighDay),
+                    $query->lessThanOrEqual('startTime', $restrictionHighTime),
                 ]),
-                $query->lessThan('start_date', $restrictionHighDay),
+                $query->lessThan('startDate', $restrictionHighDay),
                 $query->logicalAnd([
-                    $query->equals('all_day', true),
-                    $query->lessThanOrEqual('start_date', $restrictionHighDay),
+                    $query->equals('allDay', true),
+                    $query->lessThanOrEqual('startDate', $restrictionHighDay),
                 ]),
             ]),
         ]);
@@ -743,31 +743,31 @@ class IndexRepository extends AbstractRepository
 
         // before - in
         $beforeIn = [
-            $query->lessThan('start_date', (new \DateTime('@' . $arguments['startTime']))->format('Y-m-d')),
-            $query->greaterThanOrEqual('end_date', (new \DateTime('@' . $arguments['endTime']))->format('Y-m-d')),
-            $query->lessThan('end_date', (new \DateTime('@' . $arguments['endTime']))->format('Y-m-d')),
+            $query->lessThan('startDate', (new \DateTime('@' . $arguments['startTime']))->format('Y-m-d')),
+            $query->greaterThanOrEqual('endDate', (new \DateTime('@' . $arguments['endTime']))->format('Y-m-d')),
+            $query->lessThan('endDate', (new \DateTime('@' . $arguments['endTime']))->format('Y-m-d')),
         ];
         $orConstraint[] = $query->logicalAnd($beforeIn);
 
         // in - in
         $inIn = [
-            $query->greaterThanOrEqual('start_date', (new \DateTime('@' . $arguments['startTime']))->format('Y-m-d')),
-            $query->lessThan('end_date', (new \DateTime('@' . $arguments['endTime']))->format('Y-m-d')),
+            $query->greaterThanOrEqual('startDate', (new \DateTime('@' . $arguments['startTime']))->format('Y-m-d')),
+            $query->lessThan('endDate', (new \DateTime('@' . $arguments['endTime']))->format('Y-m-d')),
         ];
         $orConstraint[] = $query->logicalAnd($inIn);
 
         // in - after
         $inAfter = [
-            $query->greaterThanOrEqual('start_date', (new \DateTime('@' . $arguments['startTime']))->format('Y-m-d')),
-            $query->lessThan('start_date', (new \DateTime('@' . $arguments['endTime']))->format('Y-m-d')),
-            $query->greaterThanOrEqual('end_date', (new \DateTime('@' . $arguments['endTime']))->format('Y-m-d')),
+            $query->greaterThanOrEqual('startDate', (new \DateTime('@' . $arguments['startTime']))->format('Y-m-d')),
+            $query->lessThan('startDate', (new \DateTime('@' . $arguments['endTime']))->format('Y-m-d')),
+            $query->greaterThanOrEqual('endDate', (new \DateTime('@' . $arguments['endTime']))->format('Y-m-d')),
         ];
         $orConstraint[] = $query->logicalAnd($inAfter);
 
         // before - after
         $beforeAfter = [
-            $query->lessThan('start_date', (new \DateTime('@' . $arguments['startTime']))->format('Y-m-d')),
-            $query->greaterThan('end_date', (new \DateTime('@' . $arguments['endTime']))->format('Y-m-d')),
+            $query->lessThan('startDate', (new \DateTime('@' . $arguments['startTime']))->format('Y-m-d')),
+            $query->greaterThan('endDate', (new \DateTime('@' . $arguments['endTime']))->format('Y-m-d')),
         ];
         $orConstraint[] = $query->logicalAnd($beforeAfter);
 
@@ -787,9 +787,9 @@ class IndexRepository extends AbstractRepository
     {
         if ('withrangelast' === $field) {
             return [
-                'end_date' => $direction,
-                'start_date' => $direction,
-                'start_time' => $direction,
+                'endDate' => $direction,
+                'startDate' => $direction,
+                'startTime' => $direction,
             ];
         }
         if ('end' !== $field) {
@@ -797,8 +797,8 @@ class IndexRepository extends AbstractRepository
         }
 
         return [
-            $field . '_date' => $direction,
-            $field . '_time' => $direction,
+            $field . 'Date' => $direction,
+            $field . 'Time' => $direction,
         ];
     }
 }

--- a/Classes/Domain/Repository/IndexRepository.php
+++ b/Classes/Domain/Repository/IndexRepository.php
@@ -199,7 +199,61 @@ class IndexRepository extends AbstractRepository
         );
 
         if ($arguments['indexIds']) {
-            $constraints[] = $query->in('foreign_uid', $arguments['indexIds']);
+            $indexIds = [];
+            $tabledIndexIds = [];
+            foreach ($arguments['indexIds'] as $key => $indexId) {
+                if (is_int($key)) {
+                    // Plain integers (= deprecated old way, stays in for compatibility)
+                    $indexIds[] = $indexId;
+                } elseif (is_string($key) && is_array($indexId)) {
+                    // Table based values with array of foreign uids
+                    $tabledIndexIds[] = [
+                        'table' => $key,
+                        'indexIds' => $indexId
+                    ];
+                } elseif (is_string($key) && is_int($indexId)) {
+                    // Table based single return value
+                    $tabledIndexIds[] = [
+                         'table' => $key,
+                         'indexIds' => [$indexId]
+                    ];
+                }
+            }
+            $foreignIdConstraints = [];
+            // Old way, just accept foreignUids as provided, not checking the table.
+            // This has a caveat solved with the $tabledIndexIds
+            if ( $indexIds ) {
+                $foreignIdConstraints[] = $query->in('foreignUid', $indexIds);
+            }
+            if ( $tabledIndexIds ) {
+                // Handle each table individually on the filters
+                // allowing for uids to be table specific.
+                // If 1,3,5 on table_a are ok and 4,5,7 on table_b are ok,
+                // don't show uid 1 from table_b
+                foreach ( $tabledIndexIds as $tabledIndexId ) {
+                    if ( $tabledIndexId['indexIds'] ) {
+                        // This table has used filters and returned some allowed uids.
+                        // Providing non-existing values e.g.: -1 will remove everything
+                        // unless other elements have found elements with the filters
+                        $foreignIdConstraints[] = $query->logicalAnd([
+                            $query->equals('foreignTable', $tabledIndexId['table']),
+                            $query->in('foreignUid', $tabledIndexId['indexIds'])
+                        ]);
+                    }
+                }
+            }
+            if ( count($foreignIdConstraints) > 1 ) {
+                // Multiple valid tables should be grouped by "OR"
+                // so it's either table_a with uids 1,3,4 OR table_b with uids 1,5,7
+                $foreignIdConstraint = $query->logicalOr($foreignIdConstraints);
+            } else {
+                // Single constraint or no constraint should just be simply added
+                $foreignIdConstraint = array_shift($foreignIdConstraints);
+            }
+            // If any foreignUid constraint survived, use it on the query
+            if ( $foreignIdConstraint ) {
+                $constraints[] = $foreignIdConstraint;
+            }
         }
         if ($arguments['emptyPreResult']) {
             $constraints[] = $query->equals('uid', '-1');

--- a/Classes/Slots/CalMigration.php
+++ b/Classes/Slots/CalMigration.php
@@ -22,8 +22,8 @@ class CalMigration
      *
      * @see \HDNET\Calendarize\Updates\CalMigrationUpdate::performCalEventUpdate()
      *
-     * @SignalClass \HDNET\Calendarize\Updates\CalMigrationUpdate
-     * @SignalName performCalEventUpdatePostInsert
+     * @SignalClass(value="HDNET\Calendarize\Updates\CalMigrationUpdate")
+     * @SignalName(value="performCalEventUpdatePostInsert")
      *
      * @return array
      */

--- a/Classes/Slots/EventSearch.php
+++ b/Classes/Slots/EventSearch.php
@@ -61,7 +61,7 @@ class EventSearch
         /** @var EventRepository $eventRepository */
         $eventRepository = GeneralUtility::makeInstance(ObjectManager::class)->get(EventRepository::class);
         $searchTermHits = $eventRepository->getIdsBySearchTerm($customSearch['fullText']);
-        if ( $searchTermHits && count($searchTermHits) ) {
+        if ($searchTermHits && count($searchTermHits)) {
             $indexIds['tx_calendarize_domain_model_event'] = $searchTermHits;
         }
         return [

--- a/Classes/Slots/EventSearch.php
+++ b/Classes/Slots/EventSearch.php
@@ -25,8 +25,8 @@ class EventSearch
     /**
      * Check if we can reduce the amount of results.
      *
-     * @SignalClass \HDNET\Calendarize\Domain\Repository\IndexRepository
-     * @SignalName findBySearchPre
+     * @SignalClass(value="HDNET\Calendarize\Domain\Repository\IndexRepository")
+     * @SignalName(value="findBySearchPre")
      *
      * @param array          $indexIds
      * @param \DateTime|null $startDate
@@ -55,14 +55,17 @@ class EventSearch
         // ?tx_calendarize_calendar[customSearch][categories]=1
         // https://github.com/lochmueller/calendarize/issues/89
 
-        if (!isset($customSearch['fullText'])) {
+        if (!isset($customSearch['fullText']) || !$customSearch['fullText']) {
             return;
         }
-
+        /** @var EventRepository $eventRepository */
         $eventRepository = GeneralUtility::makeInstance(ObjectManager::class)->get(EventRepository::class);
-
+        $searchTermHits = $eventRepository->getIdsBySearchTerm($customSearch['fullText']);
+        if ( $searchTermHits && count($searchTermHits) ) {
+            $indexIds['tx_calendarize_domain_model_event'] = $searchTermHits;
+        }
         return [
-            'indexIds' => $eventRepository->getIdsBySearchTerm($customSearch['fullText']),
+            'indexIds' => $indexIds,
             'startDate' => $startDate,
             'endDate' => $endDate,
             'customSearch' => $customSearch,


### PR DESCRIPTION
This merge is a bit bigger than the last one as it fixes a rather weird bug. There is a "caution" part on the bottom too.

The following situation is needed to reproduce the error fixed by this:

- Use regular calendarize events
- Use custom made events (with a plugin for calendarize loosely based on the calendarize_news)
- Three own filters are provided by the custom events
- The fullText filter provided by calendarize events is used within in the custom made events as well
- Search for a text that produces 1 hit on each object on different uids
- Watch results

The old way the EventsSearch was written overwrites the variable instead of adding to it. This is also fixed with this release.
This is the default behaviour of the SignalSlot Dispatcher in TYPO3 ($signalArguments = $slotReturn).

When you have multiple sources on one list, the previous code allows for the "allowed" uids to be shared across tables. Even if you didn't overwrite it with your return. If calendarize event with uid 2 is a match, then automatically custom event with uid 2 would match as well, although its filter didn't add that number.
To not break older calendarize plugins, the old way of just uids is still allowed, because it worked absolutely fine with just one source.

By adding the table name to the indexIds, it ensures the correct foreign objects are taken. By the construction it is also ensured, that multiple sources can be filtered and displayed on one list together when using a shared filter like fullText. When using the extension specific filters, the regular events will not be displayed however, as they don't match. This is an expected behaviour.

Now for the bugfix part:
While trying to hook onto the signal slots, the class notation seemed off making it impossible to hook. Xdebug led the code through the constructor but didn't find the value next to the annotation, so the hooking never happened. The EventSearch.php is now a valid example to custom plugins for how hooking onto the "findBySearchPre" signal works. This was at least necessary on PHP 7.2.3 and TYPO3 10.4.8 where I tested it. The fullText filter didn't even work for the regular calendarize events before this fix.

Now for the caution part:
The same fix from EventSearch.php was implemented on the CalMigration.php in Slots.  Its signal should now work as well, but since I didn't test it, I cannot say for sure, if this makes old bugs visible which didn't register because the class was not called or just fixes a bug. I only saw, that the notation was off like on the other one and updated it accordingly.