### PR TITLE
Fix FormatUtcDateViewHelper and add some tests

### DIFF
--- a/Classes/ViewHelpers/DateTime/FormatUtcDateViewHelper.php
+++ b/Classes/ViewHelpers/DateTime/FormatUtcDateViewHelper.php
@@ -1,13 +1,12 @@
 <?php
 
-/**
- * Provide strftime function in UTC context.
- */
 declare(strict_types=1);
 
 namespace HDNET\Calendarize\ViewHelpers\DateTime;
 
 use TYPO3\CMS\Fluid\ViewHelpers\Format\DateViewHelper;
+use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Exception;
 
 /**
  * Formats the date to UTC.
@@ -17,16 +16,30 @@ class FormatUtcDateViewHelper extends DateViewHelper
     /**
      * Format dateTime to the UTC timezone.
      *
+     * @param array                     $arguments
+     * @param \Closure                  $renderChildrenClosure
+     * @param RenderingContextInterface $renderingContext
+     *
      * @return string
+     *
+     * @throws Exception
      */
-    public function render()
+    public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext)
     {
         // save configured timezone
         $timezone = date_default_timezone_get();
         // set timezone to UTC
         date_default_timezone_set('UTC');
 
-        $result = parent::render();
+        $date = $arguments['date'];
+        if ($date instanceof \DateTimeInterface) {
+            $renderChildrenClosure = function () use ($date) {
+                // Convert date to timestamp, so that it can be reparsed.
+                return $date->getTimestamp();
+            };
+        }
+
+        $result = parent::renderStatic($arguments, $renderChildrenClosure, $renderingContext);
 
         // restore timezone setting
         date_default_timezone_set($timezone);

--- a/Classes/ViewHelpers/Format/EscapeIcalTextViewHelper.php
+++ b/Classes/ViewHelpers/Format/EscapeIcalTextViewHelper.php
@@ -45,6 +45,6 @@ class EscapeIcalTextViewHelper extends AbstractViewHelper
             $value = $this->renderChildren();
         }
         // Note: The string syntax use double and single quotes!
-        return str_replace(['\\', "\n", "\r", ',', ';'], ['\\\\', '\n', '\r', '\,', '\;'], $value);
+        return str_replace(['\\', "\r\n", "\n", ',', ';'], ['\\\\', '\n', '\n', '\,', '\;'], $value);
     }
 }

--- a/Tests/Unit/ViewHelpers/DateTime/FormatUtcDateViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/DateTime/FormatUtcDateViewHelperTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace HDNET\Calendarize\Tests\ViewHelpers\DateTime;
+
+use HDNET\Calendarize\ViewHelpers\DateTime\FormatUtcDateViewHelper;
+use TYPO3\TestingFramework\Fluid\Unit\ViewHelpers\ViewHelperBaseTestcase;
+
+class FormatUtcDateViewHelperTest extends ViewHelperBaseTestcase
+{
+    /**
+     * @var string Backup of current timezone, it is manipulated in tests
+     */
+    protected $timezone;
+
+    /**
+     * @var FormatUtcDateViewHelper
+     */
+    protected $viewHelper;
+
+    protected $resetSingletonInstances = true;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->timezone = @date_default_timezone_get();
+        $this->viewHelper = new FormatUtcDateViewHelper();
+        $this->injectDependenciesIntoViewHelper($this->viewHelper);
+    }
+
+    protected function tearDown(): void
+    {
+        date_default_timezone_set($this->timezone);
+        parent::tearDown();
+    }
+
+    /**
+     * @dataProvider dateIsUtcTimezoneDataProvider
+     *
+     * @param \DateTimeInterface|string|number $date
+     * @param string                           $expected
+     */
+    public function testDateIsUtcTimezone($date, string $expected)
+    {
+        date_default_timezone_set('Europe/Moscow');
+        $format = 'Ymd\THis\Z';
+        $this->setArgumentsUnderTest(
+            $this->viewHelper,
+            [
+                'date' => $date,
+                'format' => $format,
+            ]
+        );
+        $actualResult = $this->viewHelper->initializeArgumentsAndRender();
+        self::assertEquals($expected, $actualResult);
+    }
+
+    public function dateIsUtcTimezoneDataProvider()
+    {
+        return [
+            'Bash UTC' => ['Sun Apr 30 03:01:39 UTC 2006', '20060430T030139Z'],
+            'Unix' => ['1607785200', '20201212T150000Z'],
+            'ISO 8601 / Atom' => ['2020-12-12T18:00:00+01:00', '20201212T170000Z'],
+            'DateTime' => [new \DateTime('2012-12-21T08:00:00', new \DateTimeZone('Asia/Shanghai')), '20121221T000000Z'],
+            'DateTimeImmutable' => [new \DateTimeImmutable('2016-07-02T13:01:33', new \DateTimeZone('Indian/Mayotte')), '20160702T100133Z'],
+        ];
+    }
+}

--- a/Tests/Unit/ViewHelpers/Format/EscapeIcalTextViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Format/EscapeIcalTextViewHelperTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace HDNET\Calendarize\Tests\ViewHelpers\Format;
+
+use HDNET\Calendarize\ViewHelpers\Format\EscapeIcalTextViewHelper;
+use TYPO3\TestingFramework\Fluid\Unit\ViewHelpers\ViewHelperBaseTestcase;
+
+class EscapeIcalTextViewHelperTest extends ViewHelperBaseTestcase
+{
+    /**
+     * @var EscapeIcalTextViewHelper
+     */
+    protected $viewHelper;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->viewHelper = new EscapeIcalTextViewHelper();
+    }
+
+    /**
+     * @dataProvider textEscapeDataProvider
+     *
+     * @param string $date
+     * @param string $expected
+     */
+    public function testTextEscape(string $value, string $expected)
+    {
+        $this->setArgumentsUnderTest(
+            $this->viewHelper,
+            [
+                'value' => $value,
+            ]
+        );
+        $actualResult = $this->viewHelper->initializeArgumentsAndRender();
+        self::assertEquals($expected, $actualResult);
+    }
+
+    public function textEscapeDataProvider()
+    {
+        return [
+            'Backslash' => ['\\', '\\\\'],
+            'Newline' => ["\n", '\n'],
+            'CRLF' => ["\r\n", '\n'],
+            'Semicolon' => [';', '\;'],
+            'Comma' => [',', '\,'],
+            'Colon (not)' => [':', ':'],
+            'Example text' => [
+                "This is a description\nwith a linebreak and a ; , and :",
+                'This is a description\\nwith a linebreak and a \\; \\, and :',
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
I changed the previos pull request to a draft, because I had some weird behavior and found a bug...

`DateViewHelper` uses `renderStatic` instead of `render`.
This created weird / unexspected behavior.
The tests did not help with that, however helped with date objects.