### PR TITLE
Fix timezone of dates/times in ical event adapters 

### DIFF
--- a/Classes/Controller/CalendarController.php
+++ b/Classes/Controller/CalendarController.php
@@ -397,9 +397,6 @@ class CalendarController extends AbstractController
         }
         $weekStart = (int)$this->settings['weekStart'];
         $firstDay = DateTimeUtility::convertWeekYear2DayMonthYear((int)$week, $year, $weekStart);
-        $timezone = DateTimeUtility::getTimeZone();
-        $firstDay->setTimezone($timezone);
-        $firstDay->setTime(0, 0, 0);
 
         $weekConfiguration = [
             '+0 day' => 2,

--- a/Classes/Domain/Repository/IndexRepository.php
+++ b/Classes/Domain/Repository/IndexRepository.php
@@ -451,8 +451,6 @@ class IndexRepository extends AbstractRepository
         $weekStart = (int)$weekStart;
         $daysShift = $weekStart - 1;
         $firstDay = DateTimeUtility::convertWeekYear2DayMonthYear($week, $year);
-        $timezone = DateTimeUtility::getTimeZone();
-        $firstDay->setTimezone($timezone);
         if (0 !== $daysShift) {
             $firstDay->modify('+' . $daysShift . ' days');
         }

--- a/Classes/Ical/DissectEventAdapter.php
+++ b/Classes/Ical/DissectEventAdapter.php
@@ -88,11 +88,16 @@ class DissectEventAdapter implements ICalEvent
      */
     public function getStartDate(): ?\DateTime
     {
-        if (empty($this->event->getStart())) {
+        $startDate = $this->event->getStart();
+        if (empty($startDate)) {
             return null;
         }
+        if ($this->isAllDay()) {
+            // Allows the date to be reparsed with the right timezone.
+            $startDate = $startDate->format('Y-m-d');
+        }
 
-        return DateTimeUtility::getDayStart($this->event->getStart());
+        return DateTimeUtility::getDayStart($startDate);
     }
 
     /**
@@ -104,7 +109,7 @@ class DissectEventAdapter implements ICalEvent
             return self::ALLDAY_START_TIME;
         }
 
-        return DateTimeUtility::getDaySecondsOfDateTime($this->event->getStart());
+        return DateTimeUtility::getNormalizedDaySecondsOfDateTime($this->event->getStart());
     }
 
     /**
@@ -119,6 +124,8 @@ class DissectEventAdapter implements ICalEvent
         if ($this->isAllDay()) {
             // Converts the exclusive enddate to inclusive
             $endDate = (clone $endDate)->sub(new \DateInterval('P1D'));
+            // Allows the date to be reparsed with the right timezone.
+            $endDate = $endDate->format('Y-m-d');
         }
 
         return DateTimeUtility::getDayStart($endDate);
@@ -133,7 +140,7 @@ class DissectEventAdapter implements ICalEvent
             return self::ALLDAY_END_TIME;
         }
 
-        return DateTimeUtility::getDaySecondsOfDateTime($this->event->getEnd());
+        return DateTimeUtility::getNormalizedDaySecondsOfDateTime($this->event->getEnd());
     }
 
     /**

--- a/Classes/Ical/ICalEvent.php
+++ b/Classes/Ical/ICalEvent.php
@@ -51,22 +51,23 @@ interface ICalEvent
     public function getLocation(): ?string;
 
     /**
-     * Get orginzer.
+     * Get organinzer.
      *
      * @return string|null
      */
     public function getOrganizer(): ?string;
 
     /**
-     * Get start date.
+     * Get the start date.
+     * The date is converted to the local timezone and set to the beginning of the day.
      *
      * @return \DateTime|null
      */
     public function getStartDate(): ?\DateTime;
 
     /**
-     * Get end date.
-     * This is an inclusive end date.
+     * Get the inclusive end date.
+     * The date is converted to the local timezone and set to the beginning of the day.
      *
      * @return \DateTime|null
      */
@@ -74,6 +75,7 @@ interface ICalEvent
 
     /**
      * Get start time.
+     * The time is calculated in the local timezone.
      *
      * @return int
      */
@@ -81,6 +83,7 @@ interface ICalEvent
 
     /**
      * Get end time.
+     * The time is calculated in the local timezone.
      *
      * @return int
      */

--- a/Classes/Ical/VObjectEventAdapter.php
+++ b/Classes/Ical/VObjectEventAdapter.php
@@ -105,11 +105,14 @@ class VObjectEventAdapter implements ICalEvent
         if (!isset($this->event->DTSTART)) {
             return null;
         }
+        $start = $this->event->DTSTART->getDateTime();
 
-        /** @var \Sabre\VObject\Property\ICalendar\DateTime $start */
-        $start = $this->event->DTSTART;
+        if ($this->isAllDay()) {
+            // Allows the date to be reparsed with the right timezone.
+            $start = $start->format('Y-m-d');
+        }
 
-        return DateTimeUtility::getDayStart($start->getDateTime());
+        return DateTimeUtility::getDayStart($start);
     }
 
     /**
@@ -125,6 +128,8 @@ class VObjectEventAdapter implements ICalEvent
         if ($this->isAllDay()) {
             // Converts the exclusive enddate to inclusive
             $end = (clone $end)->sub(new \DateInterval('P1D'));
+            // Allows the date to be reparsed with the right timezone.
+            $end = $end->format('Y-m-d');
         }
 
         return DateTimeUtility::getDayStart($end);
@@ -166,7 +171,7 @@ class VObjectEventAdapter implements ICalEvent
         /** @var \Sabre\VObject\Property\ICalendar\DateTime $start */
         $start = $this->event->DTSTART;
 
-        return DateTimeUtility::getDaySecondsOfDateTime($start->getDateTime());
+        return DateTimeUtility::getNormalizedDaySecondsOfDateTime($start->getDateTime());
     }
 
     /**
@@ -179,7 +184,7 @@ class VObjectEventAdapter implements ICalEvent
             return self::ALLDAY_END_TIME;
         }
 
-        return DateTimeUtility::getDaySecondsOfDateTime($end);
+        return DateTimeUtility::getNormalizedDaySecondsOfDateTime($end);
     }
 
     /**


### PR DESCRIPTION
The first commit changes `normalizeDateTimeSingle` to always return (also for timestamps and existing objects) a datetime in the server timezone.
It also improves some functions in the DateTimeUtility.

The second commit fixes the date and time handling of the ical event adapters, so that the returned time / date object is (calculated) in the server timezone.