### PR TITLE
Fix booking validation

### DIFF
--- a/Classes/Controller/BookingController.php
+++ b/Classes/Controller/BookingController.php
@@ -9,6 +9,7 @@ namespace HDNET\Calendarize\Controller;
 
 use HDNET\Calendarize\Domain\Model\Index;
 use HDNET\Calendarize\Domain\Model\Request\AbstractBookingRequest;
+use TYPO3\CMS\Extbase\Annotation as Extbase;
 
 /**
  * BookingController.
@@ -35,7 +36,7 @@ class BookingController extends AbstractController
      * @param Index                                                          $index
      * @param \HDNET\Calendarize\Domain\Model\Request\AbstractBookingRequest $request
      *
-     * @validate $request \HDNET\Calendarize\Validation\Validator\BookingRequestValidator
+     * @Extbase\Validate("\HDNET\Calendarize\Validation\Validator\BookingRequestValidator", param="request")
      */
     public function sendAction(Index $index, AbstractBookingRequest $request)
     {

--- a/Classes/Domain/Model/Request/DefaultBookingRequest.php
+++ b/Classes/Domain/Model/Request/DefaultBookingRequest.php
@@ -7,6 +7,8 @@ declare(strict_types=1);
 
 namespace HDNET\Calendarize\Domain\Model\Request;
 
+use TYPO3\CMS\Extbase\Annotation as Extbase;
+
 /**
  * DefaultBookingRequest.
  */
@@ -16,7 +18,7 @@ class DefaultBookingRequest extends AbstractBookingRequest
      * First name.
      *
      * @var string
-     * @validate NotEmpty
+     * @Extbase\Validate("NotEmpty")
      */
     protected $firstName;
 
@@ -24,7 +26,7 @@ class DefaultBookingRequest extends AbstractBookingRequest
      * Last name.
      *
      * @var string
-     * @validate NotEmpty
+     * @Extbase\Validate("NotEmpty")
      */
     protected $lastName;
 
@@ -32,8 +34,8 @@ class DefaultBookingRequest extends AbstractBookingRequest
      * E-Mail.
      *
      * @var string
-     * @validate NotEmpty
-     * @validate EmailAddress
+     * @Extbase\Validate("NotEmpty")
+     * @Extbase\Validate("EmailAddress")
      */
     protected $email;
 
@@ -48,7 +50,7 @@ class DefaultBookingRequest extends AbstractBookingRequest
      * Street.
      *
      * @var string
-     * @validate NotEmpty
+     * @Extbase\Validate("NotEmpty")
      */
     protected $street;
 
@@ -56,7 +58,7 @@ class DefaultBookingRequest extends AbstractBookingRequest
      * House number.
      *
      * @var string
-     * @validate NotEmpty
+     * @Extbase\Validate("NotEmpty")
      */
     protected $houseNumber;
 
@@ -64,7 +66,7 @@ class DefaultBookingRequest extends AbstractBookingRequest
      * ZIP.
      *
      * @var string
-     * @validate NotEmpty
+     * @Extbase\Validate("NotEmpty")
      */
     protected $zip;
 
@@ -72,7 +74,7 @@ class DefaultBookingRequest extends AbstractBookingRequest
      * City.
      *
      * @var string
-     * @validate NotEmpty
+     * @Extbase\Validate("NotEmpty")
      */
     protected $city;
 
@@ -80,7 +82,7 @@ class DefaultBookingRequest extends AbstractBookingRequest
      * Country.
      *
      * @var string
-     * @validate NotEmpty
+     * @Extbase\Validate("NotEmpty")
      */
     protected $country;
 


### PR DESCRIPTION
Replaces removed annotations with new one.
Only testet the submission and checked, if the validation works.

See typo3 changelog for more information:
[typo3#83167](https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/9.3/Deprecation-83167-ReplaceValidateWithTYPO3CMSExtbaseAnnotationValidate.html) - Replace @ validate with @ TYPO3\\CMS\\Extbase\\Annotation\\Validate