### PR TITLE
Fix SmartExclude (Language, Workspaces)

### DIFF
--- a/Classes/Domain/Model/Configuration.php
+++ b/Classes/Domain/Model/Configuration.php
@@ -16,7 +16,7 @@ use HDNET\Calendarize\Utility\DateTimeUtility;
  * Configuration for time options.
  *
  * @DatabaseTable
- * @SmartExclude("Language")
+ * @SmartExclude(excludes={"Language"})
  */
 class Configuration extends AbstractModel implements ConfigurationInterface
 {

--- a/Classes/Domain/Model/ConfigurationGroup.php
+++ b/Classes/Domain/Model/ConfigurationGroup.php
@@ -16,7 +16,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  * Logical configuration group.
  *
  * @DatabaseTable
- * @SmartExclude("Language")
+ * @SmartExclude(excludes={"Language"})
  */
 class ConfigurationGroup extends AbstractModel
 {

--- a/Classes/Domain/Model/Event.php
+++ b/Classes/Domain/Model/Event.php
@@ -21,7 +21,7 @@ use TYPO3\CMS\Extbase\Persistence\ObjectStorage;
  * Event (Default) for the calendarize function.
  *
  * @DatabaseTable
- * @SmartExclude("Workspaces")
+ * @SmartExclude(excludes={"Workspaces"})
  */
 class Event extends AbstractModel implements FeedInterface, SpeakingUrlInterface, KeSearchIndexInterface
 {

--- a/Classes/Domain/Model/Index.php
+++ b/Classes/Domain/Model/Index.php
@@ -20,7 +20,7 @@ use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
  * Index information.
  *
  * @DatabaseTable
- * @SmartExclude("Workspaces")
+ * @SmartExclude(excludes={"Workspaces"})
  */
 class Index extends AbstractModel
 {


### PR DESCRIPTION
This fixes the exclusion of languages and workspaces in the TCA / DB.
The string passed in is not a valid value, since the smart exclude annotation expects an array. Through this the annotation had no effect.

After this change some fields can be dropped.

This may caused some problems with translated records (untestet).