### PR TITLE
Fix #422 - Make aspect resolver language aware

### DIFF
--- a/Classes/Routing/Aspect/EventMapper.php
+++ b/Classes/Routing/Aspect/EventMapper.php
@@ -8,16 +8,19 @@ declare(strict_types=1);
 namespace HDNET\Calendarize\Routing\Aspect;
 
 use HDNET\Calendarize\Service\Url\Typo3Route;
+use TYPO3\CMS\Core\Context\Context;
+use TYPO3\CMS\Core\Context\LanguageAspectFactory;
 use TYPO3\CMS\Core\Routing\Aspect\PersistedMappableAspectInterface;
 use TYPO3\CMS\Core\Routing\Aspect\StaticMappableAspectInterface;
 use TYPO3\CMS\Core\Routing\RouteNotFoundException;
+use TYPO3\CMS\Core\Site\SiteLanguageAwareInterface;
 use TYPO3\CMS\Core\Site\SiteLanguageAwareTrait;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * EventMapper.
  */
-class EventMapper implements PersistedMappableAspectInterface, StaticMappableAspectInterface
+class EventMapper implements PersistedMappableAspectInterface, StaticMappableAspectInterface, SiteLanguageAwareInterface
 {
     use SiteLanguageAwareTrait;
 
@@ -43,6 +46,19 @@ class EventMapper implements PersistedMappableAspectInterface, StaticMappableAsp
      */
     public function resolve(string $value): ?string
     {
+        // Set the language in the context, so that the index repository fetches
+        // the translated record (is set in Typo3QuerySettings->initializeObject(),
+        // which is used by findByUid).
+        // This is only required, when a existing url is resolved, since the
+        // value is checked for correctness with $this->generate.
+        // Alternative: Use overlay function of the pageRepository, similar to PersistedPatternMapper
+        // @TODO: Warning: This may have unexpected site effects!
+        $context = GeneralUtility::makeInstance(Context::class);
+        $context->setAspect(
+            'language',
+            LanguageAspectFactory::createFromSiteLanguage($this->siteLanguage)
+        );
+
         $route = GeneralUtility::makeInstance(Typo3Route::class);
         $id = (string)$route->convert(['resolve' => $value], null);
 


### PR DESCRIPTION
The language aspect in the Context seems not to be set in the resolve
function. Due to this the speaking url of the generate functions
is in the default language and does not match the translated input.

The EventMapper resolver now sets the language aspect in the Context.

This is probaly not the best solution, but solves the problem.
