### PR TITLE
Fix / Migrate IfDate*ViewHelper arguments

### DIFF
--- a/Classes/ViewHelpers/IfDateLowerViewHelper.php
+++ b/Classes/ViewHelpers/IfDateLowerViewHelper.php
@@ -15,18 +15,27 @@ use HDNET\Calendarize\Utility\DateTimeUtility;
 class IfDateLowerViewHelper extends AbstractViewHelper
 {
     /**
+     * Initialize arguments.
+     */
+    public function initializeArguments(): void
+    {
+        parent::initializeArguments();
+        $this->registerArgument('base', 'mixed', '', true);
+        $this->registerArgument('check', 'mixed', '', true);
+    }
+
+    /**
      * Render the view helper.
      *
      * Note: You have to wrap this view helper in an f:if ViewHelper.
      * This VH just return a boolean evaluation value
      *
-     * @param string|\DateTime $base
-     * @param \DateTime        $check
-     *
      * @return string
      */
-    public function render($base, $check)
+    public function render()
     {
+        $base = $this->arguments['base'];
+        $check = $this->arguments['check'];
         $base = DateTimeUtility::normalizeDateTimeSingle($base);
         $check = DateTimeUtility::normalizeDateTimeSingle($check);
 

--- a/Classes/ViewHelpers/IfDateUpperViewHelper.php
+++ b/Classes/ViewHelpers/IfDateUpperViewHelper.php
@@ -15,18 +15,27 @@ use HDNET\Calendarize\Utility\DateTimeUtility;
 class IfDateUpperViewHelper extends AbstractViewHelper
 {
     /**
+     * Initialize arguments.
+     */
+    public function initializeArguments(): void
+    {
+        parent::initializeArguments();
+        $this->registerArgument('base', 'mixed', '', true);
+        $this->registerArgument('check', 'mixed', '', true);
+    }
+
+    /**
      * Render the view helper.
      *
      * Note: You have to wrap this view helper in an f:if ViewHelper.
      * This VH just return a boolean evaluation value
      *
-     * @param string|\DateTime $base
-     * @param \DateTime        $check
-     *
      * @return string
      */
-    public function render($base, $check)
+    public function render()
     {
+        $base = $this->arguments['base'];
+        $check = $this->arguments['check'];
         $base = DateTimeUtility::normalizeDateTimeSingle($base);
         $check = DateTimeUtility::normalizeDateTimeSingle($check);
 

--- a/Tests/Unit/ViewHelpers/IfDateLowerViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/IfDateLowerViewHelperTest.php
@@ -7,13 +7,13 @@ declare(strict_types=1);
 
 namespace HDNET\Calendarize\Tests\Unit\ViewHelpers;
 
-use HDNET\Calendarize\Tests\Unit\AbstractUnitTest;
 use HDNET\Calendarize\ViewHelpers\IfDateLowerViewHelper;
+use TYPO3\TestingFramework\Fluid\Unit\ViewHelpers\ViewHelperBaseTestcase;
 
 /**
  * Check if a date is lower.
  */
-class IfDateLowerViewHelperTest extends AbstractUnitTest
+class IfDateLowerViewHelperTest extends ViewHelperBaseTestcase
 {
     /**
      * @test
@@ -21,6 +21,14 @@ class IfDateLowerViewHelperTest extends AbstractUnitTest
     public function testValidCheck()
     {
         $viewHelper = new IfDateLowerViewHelper();
-        self::assertTrue($viewHelper->render(new \DateTime(), '23.04.2004'));
+        $this->injectDependenciesIntoViewHelper($viewHelper);
+        $this->setArgumentsUnderTest(
+            $viewHelper,
+            [
+                'base' => '23.04.2026',
+                'check' => new \DateTime('2020-12-14')
+            ]
+        );
+        self::assertTrue($viewHelper->initializeArgumentsAndRender());
     }
 }

--- a/Tests/Unit/ViewHelpers/IfDateUpperViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/IfDateUpperViewHelperTest.php
@@ -9,11 +9,12 @@ namespace HDNET\Calendarize\Tests\Unit\ViewHelpers;
 
 use HDNET\Calendarize\Tests\Unit\AbstractUnitTest;
 use HDNET\Calendarize\ViewHelpers\IfDateUpperViewHelper;
+use TYPO3\TestingFramework\Fluid\Unit\ViewHelpers\ViewHelperBaseTestcase;
 
 /**
  * Check if a date is upper.
  */
-class IfDateUpperViewHelperTest extends AbstractUnitTest
+class IfDateUpperViewHelperTest extends ViewHelperBaseTestcase
 {
     /**
      * @test
@@ -21,6 +22,14 @@ class IfDateUpperViewHelperTest extends AbstractUnitTest
     public function testValidCheck()
     {
         $viewHelper = new IfDateUpperViewHelper();
-        self::assertTrue($viewHelper->render(new \DateTime(), '23.04.2026'));
+        $this->injectDependenciesIntoViewHelper($viewHelper);
+        $this->setArgumentsUnderTest(
+            $viewHelper,
+            [
+                'base' => '23.04.2004',
+                'check' => new \DateTime('2020-12-14'),
+            ]
+        );
+        self::assertTrue($viewHelper->initializeArgumentsAndRender());
     }
 }


### PR DESCRIPTION
The arguments on ViewHelper render() got deprecated in 9.0 ([Deprecation: #81213](https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/9.0/Deprecation-81213-RenderMethodArgumentOnViewHelpersDeprecated.html)) and later removed later.
