### PR TITLE
[!!!] Change tillDate from timestamp to real date

### DIFF
--- a/Classes/Domain/Model/Configuration.php
+++ b/Classes/Domain/Model/Configuration.php
@@ -128,8 +128,8 @@ class Configuration extends AbstractModel implements ConfigurationInterface
     /**
      * Till date.
      *
-     * @var \DateTime
-     * @DatabaseField("\DateTime")
+     * @var \DateTime|null
+     * @DatabaseField(type="\DateTime", sql="date default NULL")
      */
     protected $tillDate;
 
@@ -400,7 +400,7 @@ class Configuration extends AbstractModel implements ConfigurationInterface
     /**
      * Get till date.
      *
-     * @return \DateTime
+     * @return \DateTime|null
      */
     public function getTillDate()
     {
@@ -410,7 +410,7 @@ class Configuration extends AbstractModel implements ConfigurationInterface
     /**
      * Set till date.
      *
-     * @param \DateTime $tillDate
+     * @param \DateTime|null $tillDate
      */
     public function setTillDate($tillDate)
     {

--- a/Classes/Updates/DateFieldUpdate.php
+++ b/Classes/Updates/DateFieldUpdate.php
@@ -10,8 +10,10 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class DateFieldUpdate extends AbstractUpdate
 {
-
     protected $title = 'Calendarize Date Field';
+
+    protected $description = 'This wizard migrates the existing start and end dates in the ' .
+        'database from a timestamp to a real date. This enables dates before 1970 and after 2038.';
 
     protected $migrationMap = [
         'tx_calendarize_domain_model_configuration' => [

--- a/Classes/Updates/TillDateFieldUpdate.php
+++ b/Classes/Updates/TillDateFieldUpdate.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HDNET\Calendarize\Updates;
+
+class TillDateFieldUpdate extends DateFieldUpdate
+{
+    protected $title = 'Migrate tillDate database format to real date';
+
+    protected $description = 'This wizard migrates the existing tillDate configurations in the ' .
+        'database from a timestamp to a real date. This enables dates before 1970 and after 2038.';
+
+    protected $migrationMap = [
+        'tx_calendarize_domain_model_configuration' => [
+            'till_date',
+        ],
+    ];
+}

--- a/Configuration/TCA/tx_calendarize_domain_model_configuration.php
+++ b/Configuration/TCA/tx_calendarize_domain_model_configuration.php
@@ -251,8 +251,7 @@ $custom = [
         'till_date' => [
             'config' => [
                 'eval' => 'date',
-                'size' => 8,
-                'default' => 0,
+                'dbType' => 'date',
             ],
             'displayCond' => [
                 'AND' => [

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -44,6 +44,7 @@ if (!(bool) \HDNET\Calendarize\Utility\ConfigurationUtility::get('disableDefault
 $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['ext/install']['update'][\HDNET\Calendarize\Updates\CalMigrationUpdate::class] = \HDNET\Calendarize\Updates\CalMigrationUpdate::class;
 $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['ext/install']['update'][\HDNET\Calendarize\Updates\NewIncludeExcludeStructureUpdate::class] = \HDNET\Calendarize\Updates\NewIncludeExcludeStructureUpdate::class;
 $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['ext/install']['update'][\HDNET\Calendarize\Updates\DateFieldUpdate::class] = \HDNET\Calendarize\Updates\DateFieldUpdate::class;
+$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['ext/install']['update'][\HDNET\Calendarize\Updates\TillDateFieldUpdate::class] = \HDNET\Calendarize\Updates\TillDateFieldUpdate::class;
 
 $GLOBALS['TYPO3_CONF_VARS']['FE']['typolinkBuilder']['record'] = \HDNET\Calendarize\Typolink\DatabaseRecordLinkBuilder::class;
 


### PR DESCRIPTION
Replaces the type of till_date from timestamp to native datetime.
This is similar to 0db3fc886fe21c763aae7b17081073d5ac1a251c.
After this the DateField Wizard must be executed.

In the code (e.g. TimeTimeTable) the date is only accessed as DateTime object, so no migration needed there.


Current ~~**problem**: How to reactivate / mark undone the wizard for all users?~~
- Extend wizard under different name


Since this is a **breaking change**, I recommend to merge this at a **later time**.