### PR TITLE
Add utility to create configurations with recurring event

### DIFF
--- a/Classes/Domain/Model/Configuration.php
+++ b/Classes/Domain/Model/Configuration.php
@@ -192,7 +192,7 @@ class Configuration extends AbstractModel implements ConfigurationInterface
     /**
      * Import ID if the item is based on an ICS structure.
      *
-     * @var string
+     * @var string|null
      * @DatabaseField("string")
      */
     protected $importId;
@@ -631,5 +631,21 @@ class Configuration extends AbstractModel implements ConfigurationInterface
     public function setOpenEndTime(bool $openEndTime)
     {
         $this->openEndTime = $openEndTime;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getImportId(): ?string
+    {
+        return $this->importId;
+    }
+
+    /**
+     * @param string|null $importId
+     */
+    public function setImportId(?string $importId): void
+    {
+        $this->importId = $importId;
     }
 }

--- a/Classes/Domain/Model/Event.php
+++ b/Classes/Domain/Model/Event.php
@@ -113,6 +113,7 @@ class Event extends AbstractModel implements FeedInterface, SpeakingUrlInterface
      * You do not need this field, if you don't use the default Event.
      *
      * @var \TYPO3\CMS\Extbase\Persistence\ObjectStorage<\HDNET\Calendarize\Domain\Model\Configuration>
+     * @TYPO3\CMS\Extbase\Annotation\ORM\Cascade("remove")
      */
     protected $calendarize;
 

--- a/Classes/Ical/DissectEventAdapter.php
+++ b/Classes/Ical/DissectEventAdapter.php
@@ -187,4 +187,12 @@ class DissectEventAdapter implements ICalEvent
 
         return ConfigurationInterface::STATE_DEFAULT;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getRRule(): array
+    {
+        return $this->event->getRRule() ?? [];
+    }
 }

--- a/Classes/Ical/EventConfigurationInterface.php
+++ b/Classes/Ical/EventConfigurationInterface.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HDNET\Calendarize\Ical;
+
+/**
+ * Provides the methods to hydrate a Configuration object.
+ * Used to create a Configuration based on an iCalendar VEVENT.
+ *
+ * Interface EventConfigurationInterface
+ */
+interface EventConfigurationInterface
+{
+    /**
+     * Value for starTime if the event is allDay.
+     */
+    public const ALLDAY_START_TIME = 0;
+    /**
+     * Value for endTime if the event is allDay.
+     */
+    public const ALLDAY_END_TIME = 0;
+
+    /**
+     * Get the start date.
+     * The date is converted to the local timezone and set to the beginning of the day.
+     *
+     * @return \DateTime|null
+     */
+    public function getStartDate(): ?\DateTime;
+
+    /**
+     * Get the inclusive end date.
+     * The date is converted to the local timezone and set to the beginning of the day.
+     *
+     * @return \DateTime|null
+     */
+    public function getEndDate(): ?\DateTime;
+
+    /**
+     * Get start time.
+     * The time is calculated in the local timezone.
+     *
+     * @return int
+     */
+    public function getStartTime(): int;
+
+    /**
+     * Get end time.
+     * The time is calculated in the local timezone.
+     *
+     * @return int
+     */
+    public function getEndTime(): int;
+
+    /**
+     * Get allDay.
+     *
+     * The "VEVENT" is also the calendar component used to specify an
+     * anniversary or daily reminder within a calendar. These events
+     * have a DATE value type for the "DTSTART" property instead of the
+     * default value type of DATE-TIME. If such a "VEVENT" has a "DTEND"
+     * property, it MUST be specified as a DATE value also.
+     *
+     * @return bool
+     */
+    public function isAllDay(): bool;
+
+    /**
+     * Get openEndTime.
+     *
+     * @return bool
+     */
+    public function isOpenEndTime(): bool;
+
+    /**
+     * Get state.
+     *
+     * @return string
+     */
+    public function getState(): string;
+
+    /**
+     * Get repeating rules.
+     *
+     * @return array
+     */
+    public function getRRule(): array;
+}

--- a/Classes/Ical/ICalEvent.php
+++ b/Classes/Ical/ICalEvent.php
@@ -4,17 +4,8 @@ declare(strict_types=1);
 
 namespace HDNET\Calendarize\Ical;
 
-interface ICalEvent
+interface ICalEvent extends EventConfigurationInterface
 {
-    /**
-     * Value for starTime if the event is allDay.
-     */
-    const ALLDAY_START_TIME = 0;
-    /**
-     * Value for endTime if the event is allDay.
-     */
-    const ALLDAY_END_TIME = 0;
-
     /**
      * Returns event data as key value array.
      *
@@ -56,63 +47,4 @@ interface ICalEvent
      * @return string|null
      */
     public function getOrganizer(): ?string;
-
-    /**
-     * Get the start date.
-     * The date is converted to the local timezone and set to the beginning of the day.
-     *
-     * @return \DateTime|null
-     */
-    public function getStartDate(): ?\DateTime;
-
-    /**
-     * Get the inclusive end date.
-     * The date is converted to the local timezone and set to the beginning of the day.
-     *
-     * @return \DateTime|null
-     */
-    public function getEndDate(): ?\DateTime;
-
-    /**
-     * Get start time.
-     * The time is calculated in the local timezone.
-     *
-     * @return int
-     */
-    public function getStartTime(): int;
-
-    /**
-     * Get end time.
-     * The time is calculated in the local timezone.
-     *
-     * @return int
-     */
-    public function getEndTime(): int;
-
-    /**
-     * Get allDay.
-     *
-     * The "VEVENT" is also the calendar component used to specify an
-     * anniversary or daily reminder within a calendar. These events
-     * have a DATE value type for the "DTSTART" property instead of the
-     * default value type of DATE-TIME. If such a "VEVENT" has a "DTEND"
-     * property, it MUST be specified as a DATE value also.
-     *
-     * @return bool
-     */
-    public function isAllDay(): bool;
-
-    /**
-     * Get openEndTime.
-     *
-     * @return bool
-     */
-    public function isOpenEndTime(): bool;
-
-    /**
-     * Get state.
-     *
-     * @return string
-     */
-    public function getState(): string;
 }

--- a/Classes/Ical/VObjectEventAdapter.php
+++ b/Classes/Ical/VObjectEventAdapter.php
@@ -223,4 +223,20 @@ class VObjectEventAdapter implements ICalEvent
 
         return ConfigurationInterface::STATE_DEFAULT;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getRRule(): array
+    {
+        if (!isset($this->event->RRULE)) {
+            return [];
+        }
+        $rrule = $this->event->RRULE->getValue();
+        if (\is_string($rrule)) {
+            $rrule = \Sabre\VObject\Property\ICalendar\Recur::stringToArray($rrule);
+        }
+
+        return $rrule;
+    }
 }

--- a/Classes/Service/EventConfigurationService.php
+++ b/Classes/Service/EventConfigurationService.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HDNET\Calendarize\Service;
+
+use Exception;
+use HDNET\Calendarize\Domain\Model\Configuration;
+use HDNET\Calendarize\Ical\EventConfigurationInterface;
+use HDNET\Calendarize\Utility\DateTimeUtility;
+use TYPO3\CMS\Extbase\Persistence\ObjectStorage;
+
+/**
+ * Class EventConfigurationService.
+ */
+class EventConfigurationService extends AbstractService
+{
+    /**
+     * Hydrates the calendarize configurations with the information from an imported event.
+     * This adds or updates (depending on the importId) the configurations in the store.
+     *
+     * @param ObjectStorage<Configuration> $calendarize
+     * @param EventConfigurationInterface  $event
+     * @param string                       $importId
+     * @param int                          $pid
+     */
+    public function hydrateCalendarize(
+        ObjectStorage $calendarize,
+        EventConfigurationInterface $event,
+        string $importId,
+        int $pid
+    ): void {
+        $configuration = $this->getOrCreateConfiguration($calendarize, $importId);
+
+        $configuration->setImportId($importId);
+        $configuration->setPid($pid);
+
+        $configuration->setType(Configuration::TYPE_TIME);
+        $configuration->setHandling(Configuration::HANDLING_INCLUDE);
+        $configuration->setState($event->getState());
+        $configuration->setAllDay($event->isAllDay());
+
+        $configuration->setStartDate($event->getStartDate());
+        $configuration->setEndDate($event->getEndDate());
+        $configuration->setStartTime($event->getStartTime());
+        $configuration->setEndTime($event->getEndTime());
+
+        $this->hydrateRecurringConfiguration($configuration, $event->getRRule());
+    }
+
+    /**
+     * Get existing configuration with the matching import id or creates a new configuration and adds it to the store.
+     *
+     * @param ObjectStorage<Configuration> $calendarize
+     * @param string                       $importId
+     *
+     * @return Configuration
+     */
+    protected function getOrCreateConfiguration(ObjectStorage $calendarize, string $importId): Configuration
+    {
+        $configuration = false;
+        // Get existing configuration if it matches the importId
+        if (0 !== $calendarize->count()) {
+            foreach ($calendarize as $item) {
+                /** @var $item Configuration */
+                if ($item->getImportId() === $importId) {
+                    $configuration = $item;
+                    break;
+                }
+            }
+        }
+        // Create configuration if not found / exists
+        if (!$configuration) {
+            $configuration = new Configuration();
+            $configuration->setImportId($importId);
+            $calendarize->attach($configuration);
+        }
+
+        return $configuration;
+    }
+
+    /**
+     * Hydrates the configuration with recurrent configuration.
+     * Invalid values are skipped.
+     *
+     * @param Configuration $configuration
+     * @param array         $rrule
+     */
+    protected function hydrateRecurringConfiguration(Configuration $configuration, array $rrule): void
+    {
+        foreach ($rrule as $key => $value) {
+            switch (strtoupper($key)) {
+                case 'FREQ':
+                    // The spelling of the frequency in RFC 5545 matches the constants in ConfigurationInterface.
+                    // Currently only a subset of frequencies is implemented (missing "SECONDLY" / "MINUTELY" / "HOURLY")
+                    $configuration->setFrequency(strtolower($value));
+                    break;
+                case 'UNTIL':
+                    try {
+                        $tillDate = new \DateTime($value);
+                    } catch (Exception $e) {
+                        break;
+                    }
+                    if ($tillDate <= $configuration->getStartDate()) {
+                        break;
+                    }
+
+                    $configuration->setTillDate(DateTimeUtility::getDayStart($tillDate));
+                    break;
+                case 'INTERVAL':
+                    $interval = (int)$value;
+                    if ($interval < 1) {
+                        break;
+                    }
+
+                    $configuration->setCounterInterval($interval);
+                    break;
+                case 'COUNT':
+                    // RFC-5545 3.3.10:
+                    // The COUNT rule part defines the number of occurrences at which to range-bound the recurrence.
+                    // The "DTSTART" property value always counts as the first occurrence.
+                    $count = (int)$value;
+                    if ($count < 1) {
+                        break;
+                    }
+
+                    // Since calendarize does not count the DTSTART as first occurrence, the count is decremented by one.
+                    $configuration->setCounterAmount($count - 1);
+                    break;
+            }
+        }
+    }
+}

--- a/Tests/Unit/Ical/ICalEventTest.php
+++ b/Tests/Unit/Ical/ICalEventTest.php
@@ -373,4 +373,30 @@ END:VCALENDAR
         self::assertEquals(69240, $event->getEndTime());
         self::assertFalse($event->isAllDay());
     }
+
+    public function testRRule()
+    {
+        $input = 'BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//CalendarizeTest
+BEGIN:VEVENT
+UID:64843636-21d6-44e3-8f8f-6174845e2342@example.com
+DTSTAMP:20050404T112124Z
+DTSTART:20050404T195534Z
+RRULE:FREQ=DAILY;INTERVAL=1;COUNT=45
+END:VEVENT
+END:VCALENDAR
+';
+        $event = $this->getEvent($input);
+        $rrule = $event->getRRule();
+
+        self::assertArrayHasKey('FREQ', $rrule);
+        self::assertEqualsIgnoringCase('DAILY', $rrule['FREQ']);
+
+        self::assertArrayHasKey('INTERVAL', $rrule);
+        self::assertEqualsIgnoringCase('1', $rrule['INTERVAL']);
+
+        self::assertArrayHasKey('COUNT', $rrule);
+        self::assertEqualsIgnoringCase('45', $rrule['COUNT']);
+    }
 }


### PR DESCRIPTION
This will add basic support for recurring event when importing iCalendar events.
Currently only these arguments from RRULE are supported:
- FREQ: daily, monthly, yearly
- COUNT / UNTIL: Limit count / end date
- INTERVAL

What is not supported (yet): e.g. 
- recurring with weekdays
- EXDATE, RDATE, EXRULE
- ...

The functionality to create configurations is now extracted into an utility, to allow other event models to reuse this logic.
Due to this I split up the ICalEvent interface into EventConfigurationInterface.

---

There is a **little catch** / open point with the configuration update:
Every created configuration has now an importId. These only get updated if the importId matches, otherwise a new configuration is added to the object store.
Through this old configurations (e.g. from imports in previous versions) stay.
However on the other side this allows the user to add extra configurations without being overwritten by an import.

Which option do you prefer? Or any other ideas to handle this?

Other question:
How to handle or log invalid values (e.g. invalid UNTIL date)? In the current implementation they are just ignored.

---

If you have the time, feel free to critically review this change.