### PR TITLE
Fix datetime conversion in extbase

### DIFF
--- a/Classes/Domain/Model/Configuration.php
+++ b/Classes/Domain/Model/Configuration.php
@@ -47,7 +47,7 @@ class Configuration extends AbstractModel implements ConfigurationInterface
     /**
      * Start date.
      *
-     * @var \DateTime
+     * @var \DateTime|null
      * @DatabaseField(type="\DateTime", sql="date default NULL")
      */
     protected $startDate;
@@ -55,7 +55,7 @@ class Configuration extends AbstractModel implements ConfigurationInterface
     /**
      * End date.
      *
-     * @var \DateTime
+     * @var \DateTime|null
      * @DatabaseField(type="\DateTime", sql="date default NULL")
      */
     protected $endDate;
@@ -248,25 +248,21 @@ class Configuration extends AbstractModel implements ConfigurationInterface
     /**
      * Get end date.
      *
-     * @return \DateTime
+     * @return \DateTime|null
      */
-    public function getEndDate()
+    public function getEndDate(): ?\DateTime
     {
-        if ($this->endDate instanceof \DateTime) {
-            $this->endDate->setTimezone(DateTimeUtility::getTimeZone());
-        }
-
-        return $this->endDate;
+        return DateTimeUtility::fixDateTimeForExtbase($this->endDate);
     }
 
     /**
      * Set end date.
      *
-     * @param \DateTime $endDate
+     * @param \DateTime|null $endDate
      */
-    public function setEndDate($endDate)
+    public function setEndDate(?\DateTime $endDate): void
     {
-        $this->endDate = $endDate;
+        $this->endDate = DateTimeUtility::fixDateTimeForDb($endDate);
     }
 
     /**
@@ -312,25 +308,21 @@ class Configuration extends AbstractModel implements ConfigurationInterface
     /**
      * Get start date.
      *
-     * @return \DateTime
+     * @return \DateTime|null
      */
-    public function getStartDate()
+    public function getStartDate(): ?\DateTime
     {
-        if ($this->startDate instanceof \DateTime) {
-            $this->startDate->setTimezone(DateTimeUtility::getTimeZone());
-        }
-
-        return $this->startDate;
+        return DateTimeUtility::fixDateTimeForExtbase($this->startDate);
     }
 
     /**
      * Set start date.
      *
-     * @param \DateTime $startDate
+     * @param \DateTime|null $startDate
      */
-    public function setStartDate($startDate)
+    public function setStartDate(?\DateTime $startDate): void
     {
-        $this->startDate = $startDate;
+        $this->startDate = DateTimeUtility::fixDateTimeForDb($startDate);
     }
 
     /**
@@ -402,9 +394,9 @@ class Configuration extends AbstractModel implements ConfigurationInterface
      *
      * @return \DateTime|null
      */
-    public function getTillDate()
+    public function getTillDate(): ?\DateTime
     {
-        return $this->tillDate;
+        return DateTimeUtility::fixDateTimeForExtbase($this->tillDate);
     }
 
     /**
@@ -412,9 +404,9 @@ class Configuration extends AbstractModel implements ConfigurationInterface
      *
      * @param \DateTime|null $tillDate
      */
-    public function setTillDate($tillDate)
+    public function setTillDate(?\DateTime $tillDate): void
     {
-        $this->tillDate = $tillDate;
+        $this->tillDate = DateTimeUtility::fixDateTimeForDb($tillDate);
     }
 
     /**

--- a/Classes/Service/IndexPreparationService.php
+++ b/Classes/Service/IndexPreparationService.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 namespace HDNET\Calendarize\Service;
 
 use HDNET\Calendarize\Register;
-use HDNET\Calendarize\Utility\DateTimeUtility;
 use HDNET\Calendarize\Utility\HelperUtility;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -54,18 +53,6 @@ class IndexPreparationService
                 $record['foreign_table'] = $tableName;
                 $record['foreign_uid'] = $uid;
                 $record['unique_register_key'] = $configurationKey;
-
-                // UTC fix
-                $record['start_date'] = \DateTime::createFromFormat(
-                    'Y-m-d H:i:s',
-                    $record['start_date']->format('Y-m-d') . ' 00:00:00',
-                    DateTimeUtility::getUtcTimeZone()
-                );
-                $record['end_date'] = \DateTime::createFromFormat(
-                    'Y-m-d H:i:s',
-                    $record['end_date']->format('Y-m-d') . ' 00:00:00',
-                    DateTimeUtility::getUtcTimeZone()
-                );
 
                 $this->prepareRecordForDatabase($record);
                 $neededItems[$key] = $record;

--- a/Classes/Utility/DateTimeUtility.php
+++ b/Classes/Utility/DateTimeUtility.php
@@ -285,4 +285,45 @@ class DateTimeUtility
 
         return $dateTime;
     }
+
+    /**
+     * Converts DateTime objects for native dates, so that they are stored "as is".
+     * This is required for Typo3 versions before 11, since they are formatted in UTC, but shouldn't.
+     *
+     * @param \DateTime|null $date
+     *
+     * @return \DateTime|null
+     */
+    public static function fixDateTimeForDb(?\DateTime $date): ?\DateTime
+    {
+        if ($date instanceof \DateTimeInterface) {
+            $typo3Version = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\Information\Typo3Version::class);
+            if ($typo3Version->getMajorVersion() < 11) {
+                $date = new \DateTime($date->format('Y-m-d\TH:i:s'), self::getUtcTimeZone());
+            }
+        }
+
+        return $date;
+    }
+
+    /**
+     * Converts the native date object from UTC to the local timezone.
+     * This is required for Typo3 versions before 11, since the dates in the db are assumed as UTC, but aren't.
+     *
+     * @param \DateTime|null $date
+     *
+     * @return \DateTime|null
+     */
+    public static function fixDateTimeForExtbase(?\DateTime $date): ?\DateTime
+    {
+        if ($date instanceof \DateTimeInterface) {
+            $typo3Version = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\Information\Typo3Version::class);
+            if ($typo3Version->getMajorVersion() < 11) {
+                $date = (clone $date)->setTimezone(self::getUtcTimeZone());
+                $date = new \DateTime($date->format('Y-m-d\TH:i:s'), self::getTimeZone());
+            }
+        }
+
+        return $date;
+    }
 }

--- a/Tests/Unit/Utility/DateTimeUtilityTest.php
+++ b/Tests/Unit/Utility/DateTimeUtilityTest.php
@@ -26,4 +26,22 @@ class DateTimeUtilityTest extends AbstractUnitTest
 
         self::assertEquals($expected, DateTimeUtility::getDaySecondsOfDateTime($dateTime), 'The seconds of the date do not match!');
     }
+
+    public function testDateTimeForDbForExtbaseAreSame()
+    {
+        $oldTimezone = @date_default_timezone_get();
+        $timezoneId = 'Europe/Moscow';
+
+        date_default_timezone_set($timezoneId);
+
+        $date = new \DateTime('2020-12-20 14:35:00');
+
+        $dateDb = DateTimeUtility::fixDateTimeForDb(clone $date);
+        $dateExt = DateTimeUtility::fixDateTimeForExtbase(clone $dateDb);
+
+        date_default_timezone_set($oldTimezone);
+
+        self::assertEquals($date, $dateExt);
+        self::assertEquals($timezoneId, $dateExt->getTimezone()->getName(), 'Output date has local timezone.');
+    }
 }


### PR DESCRIPTION
Native dates in the DB are stored / converted as UTC dates in extbase
conflicting with the Typo3 documentation. This is however fixed in
Typo3 11 (https://review.typo3.org/c/Packages/TYPO3.CMS/+/64053).
The added converter inside the models implement/"backport" this
functionality.

The helper functions can be removed in Typo3 >= 11.

It also fixes following bug:
Importing an ICalendar in a timezone offset > UTC caused all date to be an day earlier.
