### PR TITLE
Optimize timeFrameConstraints

### DIFF
--- a/Classes/Event/AddTimeFrameConstraintsEvent.php
+++ b/Classes/Event/AddTimeFrameConstraintsEvent.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HDNET\Calendarize\Event;
+
+use TYPO3\CMS\Extbase\Persistence\Generic\Qom\ConstraintInterface;
+use TYPO3\CMS\Extbase\Persistence\QueryInterface;
+
+/**
+ * This event contains the parameters for the creation of the date time constraints and allows
+ * the modification of the start and end.
+ */
+final class AddTimeFrameConstraintsEvent
+{
+    /**
+     * @var ConstraintInterface[]
+     */
+    private $constraints;
+
+    /**
+     * @var QueryInterface
+     */
+    private $query;
+
+    /**
+     * @var array
+     */
+    private $additionalArguments;
+
+    /**
+     * @var \DateTimeInterface|null
+     */
+    private $start;
+
+    /**
+     * @var \DateTimeInterface|null
+     */
+    private $end;
+
+    /**
+     * AddTimeFrameConstraintsEvent constructor.
+     *
+     * @param ConstraintInterface[]   $constraints
+     * @param QueryInterface          $query
+     * @param array                   $additionalArguments
+     * @param \DateTimeInterface|null $start
+     * @param \DateTimeInterface|null $end
+     */
+    public function __construct(
+        array &$constraints,
+        QueryInterface $query,
+        array $additionalArguments,
+        ?\DateTimeInterface $start,
+        ?\DateTimeInterface $end
+    ) {
+        $this->constraints = &$constraints;
+        $this->query = $query;
+        $this->additionalArguments = $additionalArguments;
+        $this->start = $start;
+        $this->end = $end;
+    }
+
+    /**
+     * @return ConstraintInterface[]
+     */
+    public function &getConstraints(): array
+    {
+        return $this->constraints;
+    }
+
+    /**
+     * @return QueryInterface
+     */
+    public function getQuery(): QueryInterface
+    {
+        return $this->query;
+    }
+
+    /**
+     * @return array
+     */
+    public function getAdditionalArguments(): array
+    {
+        return $this->additionalArguments;
+    }
+
+    /**
+     * @return \DateTimeInterface|null
+     */
+    public function getStart(): ?\DateTimeInterface
+    {
+        return $this->start;
+    }
+
+    /**
+     * @return \DateTimeInterface|null
+     */
+    public function getEnd(): ?\DateTimeInterface
+    {
+        return $this->end;
+    }
+
+    /**
+     * @param \DateTimeInterface|null $start
+     */
+    public function setStart(?\DateTimeInterface $start): void
+    {
+        $this->start = $start;
+    }
+
+    /**
+     * @param \DateTimeInterface|null $end
+     */
+    public function setEnd(?\DateTimeInterface $end): void
+    {
+        $this->end = $end;
+    }
+}

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -26,6 +26,11 @@ services:
         method: 'emitImportCommand'
         event: HDNET\Calendarize\Event\ImportSingleIcalEvent
 
+      - name: event.listener
+        identifier: 'legacy-slot'
+        method: 'emitAddDateTimeFrameConstraints'
+        event: HDNET\Calendarize\Event\AddTimeFrameConstraintsEvent
+
   HDNET\Calendarize\Command\CleanupCommandController:
     tags:
       - name: console.command


### PR DESCRIPTION
The time frame constraint creation now uses DateTime objects instead of
timestamps. The constraints check if the startdate is before the range
end and vice versa. This results in shorter queries.
Furthermore the date and datetime methodes are combined and are
accepting open start / end conditions.

Additionally the signal `addTimeFrameConstraints `is now replaced
by an event, however is still supported by an compatibility signal
dispatcher.

I testet this in a different timezone with some edge conditions (with and without `respectTimesInTimeFrameConstraints`).

Fixes #483 