### PR TITLE
Fix #453 - Use real dates instead of timestamps (cal migration)

### DIFF
--- a/Classes/Slots/CalMigration.php
+++ b/Classes/Slots/CalMigration.php
@@ -11,6 +11,7 @@ use HDNET\Autoloader\Annotation\SignalClass;
 use HDNET\Autoloader\Annotation\SignalName;
 use HDNET\Calendarize\Updates\CalMigrationUpdate;
 use HDNET\Calendarize\Utility\HelperUtility;
+use TYPO3\CMS\Core\Database\Query\Restriction\DeletedRestriction;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -58,7 +59,7 @@ class CalMigration
                 ->where(
                     $q->expr()->eq('import_id', $q->createNamedParameter($importId))
                 )
-                ->set('uid_foreign', (int) $recordId)
+                ->set('uid_foreign', (int)$recordId)
                 ->set('tablenames', $table);
 
             $dbQueries[] = $q->getSQL();


### PR DESCRIPTION
Since the wizard was reactivated, the timestamp / real date problem was still there.

The cal migration wizard now keeps/uses real dates instead of converting
them to timestamps (required before calendarize 6.0).
Additionally the extension cal needs not to be loaded anymore to run
the wizard.