### PR TITLE
Fix upload of multiple files

### DIFF
--- a/Classes/Domain/Model/Event.php
+++ b/Classes/Domain/Model/Event.php
@@ -94,7 +94,7 @@ class Event extends AbstractModel implements FeedInterface, SpeakingUrlInterface
      * Images.
      *
      * @var \TYPO3\CMS\Extbase\Persistence\ObjectStorage<\TYPO3\CMS\Extbase\Domain\Model\FileReference>
-     * @DatabaseField("\TYPO3\CMS\Extbase\Domain\Model\FileReference")
+     * @DatabaseField("\TYPO3\CMS\Extbase\Persistence\ObjectStorage<\TYPO3\CMS\Extbase\Domain\Model\FileReference>")
      * @TYPO3\CMS\Extbase\Annotation\ORM\Lazy
      */
     protected $images;
@@ -103,7 +103,7 @@ class Event extends AbstractModel implements FeedInterface, SpeakingUrlInterface
      * Downloads.
      *
      * @var \TYPO3\CMS\Extbase\Persistence\ObjectStorage<\TYPO3\CMS\Extbase\Domain\Model\FileReference>
-     * @DatabaseField("\TYPO3\CMS\Extbase\Domain\Model\FileReference")
+     * @DatabaseField("\TYPO3\CMS\Extbase\Persistence\ObjectStorage<\TYPO3\CMS\Extbase\Domain\Model\FileReference>")
      * @TYPO3\CMS\Extbase\Annotation\ORM\Lazy
      */
     protected $downloads;


### PR DESCRIPTION
You can now upload multiple files / images to an event record.
The DatabaseField annotation had the wrong type, so autoloader used
`FileReferenceMapper` instead of `FileReferenceObjectStorageMapper`.
This lead to a wrong TCA configuration with `'maxitems' => 1`.

This was introduced in calendarize 7.0.0 (7e218146497049ee8b8600442c52f2c2818aa6c0).

Fixes #488