### PR TITLE
[BUGFIX] do not exclude the language configuration 

### DIFF
--- a/Classes/Domain/Model/Configuration.php
+++ b/Classes/Domain/Model/Configuration.php
@@ -16,7 +16,6 @@ use HDNET\Calendarize\Utility\DateTimeUtility;
  * Configuration for time options.
  *
  * @DatabaseTable
- * @SmartExclude(excludes={"Language"})
  */
 class Configuration extends AbstractModel implements ConfigurationInterface
 {


### PR DESCRIPTION
it leads to exception in the backend if the user translates event records with index configurations

happened in TYPO3 10.4

![image](https://user-images.githubusercontent.com/25104879/107777763-91b92b00-6d43-11eb-8c8f-89127ca25476.png)
