### PR TITLE
Remove restrictions in cal migration Upgrade Wizard

### DIFF
--- a/Classes/Updates/CalMigrationUpdate.php
+++ b/Classes/Updates/CalMigrationUpdate.php
@@ -876,6 +876,11 @@ class CalMigrationUpdate extends AbstractUpdate
         $dispatcher = HelperUtility::getSignalSlotDispatcher();
         $variables = $dispatcher->dispatch(__CLASS__, __FUNCTION__, $variables);
 
+        // also get restricted (e.g. hidden) records, otherwise retrieving event uid for
+        // restricted records will always return 0
+        $q->getRestrictions()
+            ->removeAll()
+            ->add(GeneralUtility::makeInstance(DeletedRestriction::class));
         $q->select('uid')
             ->from($variables['table'])
             ->where(


### PR DESCRIPTION
Remove all restrictions except for deleted in getCalendarizeEventUid().
This is already done in the same way in the other functions in the
cal migration upgrade wizard.

This fixing a problem with the event uid sometimes being returned as 0,
for example for hidden records which resulted in errors in the conversions,
for example in sys_category_record_mm.

Resolves: #496