### PR TITLE
Set explicit identifier for upgrade wizards

### DIFF
--- a/Classes/Updates/CalMigrationUpdate.php
+++ b/Classes/Updates/CalMigrationUpdate.php
@@ -71,6 +71,11 @@ class CalMigrationUpdate extends AbstractUpdate
     Try to migrate all cal information and place the new calendarize event models in the same folder
     as the cal-records. Please note: the migration will be create calendarize default models.';
 
+    public function getIdentifier(): string
+    {
+        return 'calMigration';
+    }
+
     /**
      * Checks whether updates are required.
      *

--- a/Classes/Updates/CalMigrationUpdate.php
+++ b/Classes/Updates/CalMigrationUpdate.php
@@ -73,7 +73,7 @@ class CalMigrationUpdate extends AbstractUpdate
 
     public function getIdentifier(): string
     {
-        return 'calMigration';
+        return 'calendarize_calMigration';
     }
 
     /**

--- a/Classes/Updates/DateFieldUpdate.php
+++ b/Classes/Updates/DateFieldUpdate.php
@@ -26,6 +26,11 @@ class DateFieldUpdate extends AbstractUpdate
         ],
     ];
 
+    public function getIdentifier(): string
+    {
+        return 'dateFieldUpdate';
+    }
+
     public function executeUpdate(): bool
     {
         foreach ($this->migrationMap as $table => $fields) {

--- a/Classes/Updates/DateFieldUpdate.php
+++ b/Classes/Updates/DateFieldUpdate.php
@@ -28,7 +28,7 @@ class DateFieldUpdate extends AbstractUpdate
 
     public function getIdentifier(): string
     {
-        return 'dateFieldUpdate';
+        return 'calendarize_dateField';
     }
 
     public function executeUpdate(): bool

--- a/Classes/Updates/NewIncludeExcludeStructureUpdate.php
+++ b/Classes/Updates/NewIncludeExcludeStructureUpdate.php
@@ -24,6 +24,12 @@ class NewIncludeExcludeStructureUpdate extends AbstractUpdate
      */
     protected $title = 'Migrate the calendarize configurations to the new include/exclude/override/cutout structure';
 
+    public function getIdentifier(): string
+    {
+        return 'newIncludeExcludeStructure';
+    }
+
+
     /**
      * Checks whether updates are required.
      *

--- a/Classes/Updates/NewIncludeExcludeStructureUpdate.php
+++ b/Classes/Updates/NewIncludeExcludeStructureUpdate.php
@@ -26,7 +26,7 @@ class NewIncludeExcludeStructureUpdate extends AbstractUpdate
 
     public function getIdentifier(): string
     {
-        return 'newIncludeExcludeStructure';
+        return 'calendarize_newIncludeExcludeStructure';
     }
 
 

--- a/Classes/Updates/TillDateFieldUpdate.php
+++ b/Classes/Updates/TillDateFieldUpdate.php
@@ -16,4 +16,9 @@ class TillDateFieldUpdate extends DateFieldUpdate
             'till_date',
         ],
     ];
+
+    public function getIdentifier(): string
+    {
+        return 'tillDateFieldUpdate';
+    }
 }

--- a/Classes/Updates/TillDateFieldUpdate.php
+++ b/Classes/Updates/TillDateFieldUpdate.php
@@ -19,6 +19,6 @@ class TillDateFieldUpdate extends DateFieldUpdate
 
     public function getIdentifier(): string
     {
-        return 'tillDateFieldUpdate';
+        return 'calendarize_tillDateField';
     }
 }

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -41,10 +41,10 @@ if (!(bool) \HDNET\Calendarize\Utility\ConfigurationUtility::get('disableDefault
     ]
 );
 
-$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['ext/install']['update']['calMigration'] = \HDNET\Calendarize\Updates\CalMigrationUpdate::class;
-$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['ext/install']['update']['newIncludeExcludeStructure'] = \HDNET\Calendarize\Updates\NewIncludeExcludeStructureUpdate::class;
-$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['ext/install']['update']['dateFieldUpdate'] = \HDNET\Calendarize\Updates\DateFieldUpdate::class;
-$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['ext/install']['update']['tillDateFieldUpdate'] = \HDNET\Calendarize\Updates\TillDateFieldUpdate::class;
+$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['ext/install']['update']['calendarize_calMigration'] = \HDNET\Calendarize\Updates\CalMigrationUpdate::class;
+$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['ext/install']['update']['calendarize_newIncludeExcludeStructure'] = \HDNET\Calendarize\Updates\NewIncludeExcludeStructureUpdate::class;
+$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['ext/install']['update']['calendarize_dateField'] = \HDNET\Calendarize\Updates\DateFieldUpdate::class;
+$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['ext/install']['update']['calendarize_tillDateField'] = \HDNET\Calendarize\Updates\TillDateFieldUpdate::class;
 
 $GLOBALS['TYPO3_CONF_VARS']['FE']['typolinkBuilder']['record'] = \HDNET\Calendarize\Typolink\DatabaseRecordLinkBuilder::class;
 

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -41,10 +41,10 @@ if (!(bool) \HDNET\Calendarize\Utility\ConfigurationUtility::get('disableDefault
     ]
 );
 
-$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['ext/install']['update'][\HDNET\Calendarize\Updates\CalMigrationUpdate::class] = \HDNET\Calendarize\Updates\CalMigrationUpdate::class;
-$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['ext/install']['update'][\HDNET\Calendarize\Updates\NewIncludeExcludeStructureUpdate::class] = \HDNET\Calendarize\Updates\NewIncludeExcludeStructureUpdate::class;
-$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['ext/install']['update'][\HDNET\Calendarize\Updates\DateFieldUpdate::class] = \HDNET\Calendarize\Updates\DateFieldUpdate::class;
-$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['ext/install']['update'][\HDNET\Calendarize\Updates\TillDateFieldUpdate::class] = \HDNET\Calendarize\Updates\TillDateFieldUpdate::class;
+$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['ext/install']['update']['calMigration'] = \HDNET\Calendarize\Updates\CalMigrationUpdate::class;
+$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['ext/install']['update']['newIncludeExcludeStructure'] = \HDNET\Calendarize\Updates\NewIncludeExcludeStructureUpdate::class;
+$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['ext/install']['update']['dateFieldUpdate'] = \HDNET\Calendarize\Updates\DateFieldUpdate::class;
+$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['ext/install']['update']['tillDateFieldUpdate'] = \HDNET\Calendarize\Updates\TillDateFieldUpdate::class;
 
 $GLOBALS['TYPO3_CONF_VARS']['FE']['typolinkBuilder']['record'] = \HDNET\Calendarize\Typolink\DatabaseRecordLinkBuilder::class;
 


### PR DESCRIPTION
This makes it easier to execute the wizards from the command line
(by using the identifier, not the fully qualified class name).

https://docs.typo3.org/m/typo3/reference-coreapi/master/en-us/ApiOverview/UpdateWizards/Creation.html#registering-wizard

Before:

![image](https://user-images.githubusercontent.com/13206455/110201241-56051300-7e62-11eb-8e63-f7074b41286d.png)


After:

![image](https://user-images.githubusercontent.com/13206455/110201207-2fdf7300-7e62-11eb-83ac-2d46c4a0f899.png)
