### PR TITLE
Add extension key to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -65,6 +65,7 @@
 	},
 	"extra": {
 		"typo3/cms": {
+			"extension-key": "calendarize",
 			"cms-package-dir": "{$vendor-dir}/typo3/cms",
 			"web-dir": ".Build/Web",
 			"Package": {


### PR DESCRIPTION
Define extension key in extra key. This prevents a warning being
generated when running Composer commands in combination with newer
versions of TYPO3

Resolves: #506