### PR TITLE
Fix generation of translation parent uid in index

### DIFF
--- a/Classes/Service/IndexPreparationService.php
+++ b/Classes/Service/IndexPreparationService.php
@@ -36,7 +36,7 @@ class IndexPreparationService
         }
 
         $register = Register::getRegister();
-        $fieldName = isset($register[$configurationKey]['fieldName']) ? $register[$configurationKey]['fieldName'] : 'calendarize';
+        $fieldName = $register[$configurationKey]['fieldName'] ?? 'calendarize';
         $configurations = GeneralUtility::intExplode(',', $rawRecord[$fieldName], true);
 
         $transPointer = $GLOBALS['TCA'][$tableName]['ctrl']['transOrigPointerField'] ?? false; // e.g. l10n_parent
@@ -74,14 +74,14 @@ class IndexPreparationService
      * @param string $tableName
      * @param array  $record
      */
-    protected function addLanguageInformation(array &$neededItems, $tableName, array $record)
+    protected function addLanguageInformation(array &$neededItems, string $tableName, array $record): void
     {
         $languageField = $GLOBALS['TCA'][$tableName]['ctrl']['languageField'] ?? false; // e.g. sys_language_uid
         $transPointer = $GLOBALS['TCA'][$tableName]['ctrl']['transOrigPointerField'] ?? false; // e.g. l10n_parent
 
         if ($transPointer && (int)$record[$transPointer] > 0) {
             foreach ($neededItems as $key => $value) {
-                $originalRecord = BackendUtility::getRecord($value['foreign_table'], $value['foreign_uid']);
+                $originalRecord = BackendUtility::getRecord($value['foreign_table'], $value['foreign_uid'], $transPointer);
 
                 $searchFor = $value;
                 $searchFor['foreign_uid'] = (int)$originalRecord[$transPointer];
@@ -161,10 +161,10 @@ class IndexPreparationService
 
         $addFields = [];
         if (isset($ctrl['tstamp'])) {
-            $addFields['tstamp'] = (int) $record[$ctrl['tstamp']];
+            $addFields['tstamp'] = (int)$record[$ctrl['tstamp']];
         }
         if (isset($ctrl['crdate'])) {
-            $addFields['crdate'] = (int) $record[$ctrl['crdate']];
+            $addFields['crdate'] = (int)$record[$ctrl['crdate']];
         }
 
         foreach ($neededItems as $key => $value) {

--- a/Classes/Service/IndexPreparationService.php
+++ b/Classes/Service/IndexPreparationService.php
@@ -59,9 +59,10 @@ class IndexPreparationService
             }
         }
 
+        // Language information must be added before ctrl/enable information
+        $this->addLanguageInformation($neededItems, $tableName, $rawRecord);
         $this->addEnableFieldInformation($neededItems, $tableName, $rawRecord);
         $this->addCtrlFieldInformation($neededItems, $tableName, $rawRecord);
-        $this->addLanguageInformation($neededItems, $tableName, $rawRecord);
 
         return $neededItems;
     }

--- a/Classes/Service/IndexerService.php
+++ b/Classes/Service/IndexerService.php
@@ -44,23 +44,21 @@ class IndexerService extends AbstractService
         $this->signalSlot->dispatch(__CLASS__, __FUNCTION__ . 'Pre', [$this]);
 
         $this->removeInvalidConfigurationIndex();
-        $q = HelperUtility::getDatabaseConnection(self::TABLE_NAME)->createQueryBuilder();
-
-        $q->getRestrictions()
-            ->removeAll()
-            ->add(GeneralUtility::makeInstance(DeletedRestriction::class));
 
         foreach (Register::getRegister() as $key => $configuration) {
             $tableName = $configuration['tableName'];
             $this->removeInvalidRecordIndex($tableName);
 
-            $q->resetQueryParts();
+            $q = HelperUtility::getDatabaseConnection($tableName)->createQueryBuilder();
+            $q->getRestrictions()
+                ->removeAll()
+                ->add(GeneralUtility::makeInstance(DeletedRestriction::class));
 
             $transPointer = $GLOBALS['TCA'][$tableName]['ctrl']['transOrigPointerField'] ?? false; // e.g. l10n_parent
 
             if ($transPointer) {
-                // Note: In loclized tables, it is important, that the "default language records" are indexed first, so the
-                // overlays can connect with l10n_paretn to the right default record.
+                // Note: In localized tables, it is important, that the "default language records" are indexed first, so the
+                // overlays can connect with l10n_parent to the right default record.
                 $q->select('uid')
                     ->from($tableName)
                     ->orderBy((string)$transPointer);

--- a/Classes/Service/TcaInformation.php
+++ b/Classes/Service/TcaInformation.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 
 namespace HDNET\Calendarize\Service;
 
+use HDNET\Calendarize\Domain\Model\ConfigurationInterface;
 use HDNET\Calendarize\Utility\DateTimeUtility;
 use HDNET\Calendarize\Utility\TranslateUtility;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
@@ -94,7 +95,7 @@ class TcaInformation extends AbstractService
                 }
                 $entry .= ' (' . $start . ' - ' . $end . ')';
             }
-            $entry .= ($event['state'] != 'default') ? ' ' . ucfirst($event['state']) : '';
+            $entry .= (ConfigurationInterface::STATE_DEFAULT !== $event['state']) ? ' ' . ucfirst($event['state']) : '';
             $items[] = $entry;
         }
         if (!$items) {

--- a/Configuration/TCA/tx_calendarize_domain_model_index.php
+++ b/Configuration/TCA/tx_calendarize_domain_model_index.php
@@ -8,6 +8,15 @@ use HDNET\Calendarize\Domain\Model\Index;
 
 $base = ModelUtility::getTcaInformation(Index::class);
 
+// Removed unused fields, because the records are not accessible by the user
+unset(
+    // Stores changes after translation was made
+    $base['ctrl']['transOrigDiffSourceField'],
+    $base['columns']['l10n_diffsource'],
+    // Prevents editing of records for non admins
+    $base['ctrl']['editlock'],
+);
+
 $custom = [
     'ctrl' => [
         'hideTable' => true,


### PR DESCRIPTION
- Fix #504 - Fix generation of translation parent uid in index
  - The Reindex scheduler should be run afterwards
- Remove unused fields from index 
  - l10n_diffsource
  - editlock
- Minor fixes and improvements