### PR TITLE
Fixes editlock, limit in past view, overwrite / relative Dates, prefix translated, categories for non-admins

### DIFF
--- a/Classes/Domain/Repository/IndexRepository.php
+++ b/Classes/Domain/Repository/IndexRepository.php
@@ -304,7 +304,9 @@ class IndexRepository extends AbstractRepository
         $constraints[] = $query->lessThanOrEqual('startDate', $now->format('Y-m-d'));
         $sort = QueryInterface::ORDER_ASCENDING === $sort ? QueryInterface::ORDER_ASCENDING : QueryInterface::ORDER_DESCENDING;
         $query->setOrderings($this->getSorting($sort));
-        $query->setLimit($limit);
+        if ($limit > 0) {
+            $query->setLimit($limit);
+        }
 
         return $this->matchAndExecute($query, $constraints);
     }

--- a/Configuration/FlexForms/Calendar.xml
+++ b/Configuration/FlexForms/Calendar.xml
@@ -170,6 +170,13 @@
 					<settings.useRelativeDate>
 						<TCEforms>
 							<label>LLL:EXT:calendarize/Resources/Private/Language/locallang.xlf:useRelativeDate</label>
+							<displayCond>
+								<OR>
+									<numIndex index="0">FIELD:switchableControllerActions:=:Calendar->list;Calendar->detail</numIndex>
+									<numIndex index="1">FIELD:switchableControllerActions:=:Calendar->list</numIndex>
+									<numIndex index="2">FIELD:switchableControllerActions:=:Calendar->latest</numIndex>
+								</OR>
+							</displayCond>
 							<onChange>reload</onChange>
 							<config>
 								<type>check</type>
@@ -185,12 +192,14 @@
 									<OR>
 										<numIndex index="0">FIELD:switchableControllerActions:=:Calendar->list;Calendar->detail</numIndex>
 										<numIndex index="1">FIELD:switchableControllerActions:=:Calendar->list</numIndex>
+										<numIndex index="2">FIELD:switchableControllerActions:=:Calendar->latest</numIndex>
 									</OR>
 								</AND>
 							</displayCond>
 							<config>
 								<type>input</type>
 								<eval>datetime</eval>
+								<renderType>inputDateTime</renderType>
 							</config>
 						</TCEforms>
 					</settings.overrideStartdate>
@@ -203,12 +212,14 @@
 									<OR>
 										<numIndex index="0">FIELD:switchableControllerActions:=:Calendar->list;Calendar->detail</numIndex>
 										<numIndex index="1">FIELD:switchableControllerActions:=:Calendar->list</numIndex>
+										<numIndex index="2">FIELD:switchableControllerActions:=:Calendar->latest</numIndex>
 									</OR>
 								</AND>
 							</displayCond>
 							<config>
 								<type>input</type>
 								<eval>datetime</eval>
+								<renderType>inputDateTime</renderType>
 							</config>
 						</TCEforms>
 					</settings.overrideEnddate>
@@ -221,6 +232,7 @@
 									<OR>
 										<numIndex index="0">FIELD:switchableControllerActions:=:Calendar->list;Calendar->detail</numIndex>
 										<numIndex index="1">FIELD:switchableControllerActions:=:Calendar->list</numIndex>
+										<numIndex index="2">FIELD:switchableControllerActions:=:Calendar->latest</numIndex>
 									</OR>
 								</AND>
 							</displayCond>
@@ -239,6 +251,7 @@
 									<OR>
 										<numIndex index="0">FIELD:switchableControllerActions:=:Calendar->list;Calendar->detail</numIndex>
 										<numIndex index="1">FIELD:switchableControllerActions:=:Calendar->list</numIndex>
+										<numIndex index="2">FIELD:switchableControllerActions:=:Calendar->latest</numIndex>
 									</OR>
 								</AND>
 							</displayCond>

--- a/Configuration/TCA/Overrides/tx_calendarize_domain_model_event.php
+++ b/Configuration/TCA/Overrides/tx_calendarize_domain_model_event.php
@@ -4,12 +4,18 @@ declare(strict_types=1);
 
 use HDNET\Calendarize\Register;
 use HDNET\Calendarize\Utility\ConfigurationUtility;
-use TYPO3\CMS\Core\Category\CategoryRegistry;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 
 if (!(bool)ConfigurationUtility::get('disableDefaultEvent')) {
     Register::extTables(Register::getDefaultCalendarizeConfiguration());
 
-    $categoryRegistry = GeneralUtility::makeInstance(CategoryRegistry::class);
-    $categoryRegistry->add('calendarize', 'tx_calendarize_domain_model_event');
+    ExtensionManagementUtility::makeCategorizable(
+        'calendarize',
+        'tx_calendarize_domain_model_event',
+        'categories',
+        [
+            // Allow backend users to edit this record
+            'exclude' => false,
+        ]
+    );
 }

--- a/Configuration/TCA/tx_calendarize_domain_model_event.php
+++ b/Configuration/TCA/tx_calendarize_domain_model_event.php
@@ -21,6 +21,7 @@ $custom = [
     ],
     'columns' => [
         'title' => [
+            'l10n_mode' => 'prefixLangTitle',
             'config' => [
                 'eval' => 'required',
             ],

--- a/Configuration/TCA/tx_calendarize_domain_model_index.php
+++ b/Configuration/TCA/tx_calendarize_domain_model_index.php
@@ -15,6 +15,7 @@ unset(
     $base['columns']['l10n_diffsource'],
     // Prevents editing of records for non admins
     $base['ctrl']['editlock'],
+    $base['columns']['editlock'],
 );
 
 $custom = [


### PR DESCRIPTION
- Addition to #501: Remove TCA definition for editlock
- Fix empty limit in past view
- Fix visibility of `useRelativeDate` and `overwrite*` (#512)
- Prefix translated event tile (e.g. `[Translate to German:]`)
- Make categories editable by users