### PR TITLE
Fix #526 - remove trailing comma

### DIFF
--- a/Configuration/TCA/tx_calendarize_domain_model_index.php
+++ b/Configuration/TCA/tx_calendarize_domain_model_index.php
@@ -15,7 +15,7 @@ unset(
     $base['columns']['l10n_diffsource'],
     // Prevents editing of records for non admins
     $base['ctrl']['editlock'],
-    $base['columns']['editlock'],
+    $base['columns']['editlock']
 );
 
 $custom = [


### PR DESCRIPTION
Trailing comma's are not allowed in calls to unset() in PHP 7.2 or earlier.

I checked the rest of the files with `phpcs -p --standard=PHPCompatibility --runtime-set testVersion 7.2-7.4 .` and found no more errors.

Similar to #525 
Fixes #526 