### PR TITLE
Show page title in list of pids in BE module

### DIFF
--- a/Classes/Controller/BackendController.php
+++ b/Classes/Controller/BackendController.php
@@ -70,12 +70,14 @@ class BackendController extends AbstractController
     protected function getPageTitles(array $pids): array
     {
         foreach ($pids as $pageId) {
-            $row = BackendUtility::getRecord('pages', $pageId, 'title');
-            if ($row['title'] ?? '') {
-                $results[$pageId] = '"' . $row['title'] . '" (#' . $pageId . ')';
-            } else {
-                $results[$pageId] = '#' . $pageId;
+            $row = BackendUtility::getRecord('pages', $pageId);
+            if ($row) {
+                $title = BackendUtility::getRecordTitle('pages', $row);
+                $results[$pageId] = '"' . $title . '" (#' . $pageId . ')';
+                continue;
             }
+            // fallback to uid
+            $results[$pageId] = '#' . $pageId;
         }
         return $results;
     }

--- a/Classes/Controller/BackendController.php
+++ b/Classes/Controller/BackendController.php
@@ -38,7 +38,7 @@ class BackendController extends AbstractController
         $this->view->assignMultiple([
             'indices' => $indices,
             'typeLocations' => $typeLocations,
-            'pids' => $pids,
+            'pids' => $this->getPageTitles($pids),
             'settings' => $this->settings,
             'options' => $options,
         ]);
@@ -65,6 +65,19 @@ class BackendController extends AbstractController
         $pids = array_unique($pids);
 
         return array_combine($pids, $pids);
+    }
+
+    protected function getPageTitles(array $pids): array
+    {
+        foreach ($pids as $pageId) {
+            $row = BackendUtility::getRecord('pages', $pageId, 'title');
+            if ($row['title'] ?? '') {
+                $results[$pageId] = '"' . $row['title'] . '" (#' . $pageId . ')';
+            } else {
+                $results[$pageId] = '#' . $pageId;
+            }
+        }
+        return $results;
     }
 
     /**

--- a/Classes/ViewHelpers/Backend/PageTitleViewHelper.php
+++ b/Classes/ViewHelpers/Backend/PageTitleViewHelper.php
@@ -25,14 +25,16 @@ class PageTitleViewHelper extends AbstractViewHelper
     }
 
     /**
-     * Render.
+     * Render the title of a page
      *
      * @return string
+     *
+     * @deprecated
      */
     public function render(): string
     {
         $uid = (int)$this->arguments['uid'];
-        $record = BackendUtility::getRecord('pages', $uid);
+        $record = BackendUtility::getRecord('pages', $uid, 'title');
 
         return (string)$record['title'];
     }

--- a/Resources/Private/Templates/Backend/List.html
+++ b/Resources/Private/Templates/Backend/List.html
@@ -7,6 +7,7 @@
 <f:layout name="Backend"/>
 
 <f:section name="Content">
+
 	<h1>Calendarize</h1>
 
 	<f:flashMessages/>
@@ -39,14 +40,12 @@
 		<f:if condition="{typeLocations}">
 			<f:then>
 				<p>
-					<f:for each="{typeLocations}" key="table" as="pids">
-						<f:for each="{pids}" key="pid" as="value">
+					<f:for each="{typeLocations}" key="table" as="typePids">
+						<f:for each="{typePids}" key="pid" as="value">
 							<be:link.newRecord class="btn btn-primary" table="{table}" pid="{pid}"
 																 returnUrl="{f:be.uri(route: 'web_CalendarizeCalendarize')}">
 								<core:icon identifier="actions-document-new"/>
-								{value} on "
-								<c:backend.pageTitle uid="{pid}"/>
-								" (#{pid})
+								{value} on {pids.{pid}}
 							</be:link.newRecord>
 						</f:for>
 					</f:for>


### PR DESCRIPTION
This change will show the same text for each page in the list of
pids as is already used for the "create new" buttons.

Before, only the pid was shown, now the title is displayed as well.

In order to not fetch the page title twice, we drop the pageTitle
ViewHelper and use the page title as already fetched in the Controller
action.

Resolves: #519