### PR TITLE
Feature/slug - generation

### DIFF
--- a/Classes/Event/BaseSlugGenerationEvent.php
+++ b/Classes/Event/BaseSlugGenerationEvent.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HDNET\Calendarize\Event;
+
+use TYPO3\CMS\Extbase\DomainObject\DomainObjectInterface;
+
+final class BaseSlugGenerationEvent
+{
+    /**
+     * @var string
+     */
+    private $uniqueRegisterKey;
+
+    /**
+     * @var DomainObjectInterface|null
+     */
+    private $model;
+
+    /**
+     * @var array
+     */
+    private $record;
+
+    /**
+     * @var string
+     */
+    private $baseSlug;
+
+    /**
+     * BaseSlugGenerationEvent constructor.
+     *
+     * @param string                $uniqueRegisterKey
+     * @param DomainObjectInterface $model
+     * @param array                 $record
+     * @param string                $baseSlug
+     */
+    public function __construct(
+        string $uniqueRegisterKey,
+        DomainObjectInterface $model,
+        array $record,
+        string $baseSlug
+    ) {
+        $this->uniqueRegisterKey = $uniqueRegisterKey;
+        $this->model = $model;
+        $this->record = $record;
+        $this->baseSlug = $baseSlug;
+    }
+
+    /**
+     * @return string
+     */
+    public function getBaseSlug(): string
+    {
+        return $this->baseSlug;
+    }
+
+    /**
+     * @param string $baseSlug
+     */
+    public function setBaseSlug(string $baseSlug): void
+    {
+        $this->baseSlug = $baseSlug;
+    }
+
+    /**
+     * @return DomainObjectInterface|null
+     */
+    public function getModel(): ?DomainObjectInterface
+    {
+        return $this->model;
+    }
+
+    /**
+     * @return string
+     */
+    public function getUniqueRegisterKey(): string
+    {
+        return $this->uniqueRegisterKey;
+    }
+
+    /**
+     * @return array
+     */
+    public function getRecord(): array
+    {
+        return $this->record;
+    }
+}

--- a/Classes/Event/SlugSuffixGenerationEvent.php
+++ b/Classes/Event/SlugSuffixGenerationEvent.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HDNET\Calendarize\Event;
+
+final class SlugSuffixGenerationEvent
+{
+    /**
+     * @var string
+     */
+    private $uniqueRegisterKey;
+
+    /**
+     * @var array
+     */
+    private $record;
+
+    /**
+     * @var string
+     */
+    private $slug;
+
+    /**
+     * SlugSuffixGenerationEvent constructor.
+     *
+     * @param string $uniqueRegisterKey
+     * @param array  $record
+     * @param string $slug
+     */
+    public function __construct(string $uniqueRegisterKey, array $record, string $slug)
+    {
+        $this->uniqueRegisterKey = $uniqueRegisterKey;
+        $this->record = $record;
+        $this->slug = $slug;
+    }
+
+    /**
+     * @return string
+     */
+    public function getUniqueRegisterKey(): string
+    {
+        return $this->uniqueRegisterKey;
+    }
+
+    /**
+     * @return array
+     */
+    public function getRecord(): array
+    {
+        return $this->record;
+    }
+
+    /**
+     * @return string
+     */
+    public function getSlug(): string
+    {
+        return $this->slug;
+    }
+
+    /**
+     * @param string $slug
+     */
+    public function setSlug(string $slug): void
+    {
+        $this->slug = $slug;
+    }
+}

--- a/Classes/Service/IndexPreparationService.php
+++ b/Classes/Service/IndexPreparationService.php
@@ -17,7 +17,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  * Helper class for the IndexService
  * Prepare the index.
  */
-class IndexPreparationService
+class IndexPreparationService extends AbstractService
 {
     /**
      * Build the index for one element.

--- a/Classes/Service/IndexPreparationService.php
+++ b/Classes/Service/IndexPreparationService.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace HDNET\Calendarize\Service;
 
 use HDNET\Calendarize\Register;
+use HDNET\Calendarize\Service\Url\SlugService;
 use HDNET\Calendarize\Utility\HelperUtility;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -19,6 +20,16 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class IndexPreparationService extends AbstractService
 {
+    /**
+     * @var SlugService
+     */
+    protected $slugService;
+
+    public function __construct(SlugService $slugService)
+    {
+        $this->slugService = $slugService;
+    }
+
     /**
      * Build the index for one element.
      *
@@ -63,6 +74,7 @@ class IndexPreparationService extends AbstractService
         $this->addLanguageInformation($neededItems, $tableName, $rawRecord);
         $this->addEnableFieldInformation($neededItems, $tableName, $rawRecord);
         $this->addCtrlFieldInformation($neededItems, $tableName, $rawRecord);
+        $this->addSlugInformation($neededItems, $configurationKey, $rawRecord);
 
         return $neededItems;
     }
@@ -169,6 +181,21 @@ class IndexPreparationService extends AbstractService
 
         foreach ($neededItems as $key => $value) {
             $neededItems[$key] = array_merge($value, $addFields);
+        }
+    }
+
+    /**
+     * Add slug to each index.
+     *
+     * @param array  $neededItems
+     * @param string $uniqueRegisterKey
+     * @param array  $record
+     */
+    protected function addSlugInformation(array &$neededItems, string $uniqueRegisterKey, array $record): void
+    {
+        $slugs = $this->slugService->generateSlugForItems($uniqueRegisterKey, $record, $neededItems);
+        foreach ($neededItems as $key => $value) {
+            $neededItems[$key] = array_merge($value, $slugs[$key] ?? []);
         }
     }
 

--- a/Classes/Service/IndexerService.php
+++ b/Classes/Service/IndexerService.php
@@ -210,7 +210,15 @@ class IndexerService extends AbstractService
 
         foreach ($neededItems as $neededKey => $neededItem) {
             foreach ($currentItems as $currentKey => $currentItem) {
-                if (ArrayUtility::isEqualArray($neededItem, $currentItem)) {
+                if (ArrayUtility::isEqualArray($neededItem, $currentItem, ['tstamp', 'crdate', 'slug'])) {
+                    // Check if the current slug starts with the new slug
+                    // Prevents regeneration for slugs with counting suffixes (added before insertion)
+                    // False positives are possible (e.g. single event where a part gets removed)
+                    if (0 !== mb_stripos($currentItem['slug'] ?? '', $neededItem['slug'], 0, 'utf-8')) {
+                        // Slug changed
+                        continue;
+                    }
+
                     unset($neededItems[$neededKey], $currentItems[$currentKey]);
 
                     break;

--- a/Classes/Service/IndexerService.php
+++ b/Classes/Service/IndexerService.php
@@ -31,9 +31,17 @@ class IndexerService extends AbstractService
      */
     protected $signalSlot;
 
-    public function __construct()
-    {
-        $this->signalSlot = GeneralUtility::makeInstance(Dispatcher::class);
+    /**
+     * @var IndexPreparationService
+     */
+    protected $preparationService;
+
+    public function __construct(
+        Dispatcher $dispatcher,
+        IndexPreparationService $preparationService
+    ) {
+        $this->signalSlot = $dispatcher;
+        $this->preparationService = $preparationService;
     }
 
     /**
@@ -54,22 +62,18 @@ class IndexerService extends AbstractService
                 ->removeAll()
                 ->add(GeneralUtility::makeInstance(DeletedRestriction::class));
 
-            $transPointer = $GLOBALS['TCA'][$tableName]['ctrl']['transOrigPointerField'] ?? false; // e.g. l10n_parent
+            $q->select('uid')
+                ->from($tableName);
 
+            $transPointer = $GLOBALS['TCA'][$tableName]['ctrl']['transOrigPointerField'] ?? false; // e.g. l10n_parent
             if ($transPointer) {
                 // Note: In localized tables, it is important, that the "default language records" are indexed first, so the
                 // overlays can connect with l10n_parent to the right default record.
-                $q->select('uid')
-                    ->from($tableName)
-                    ->orderBy((string)$transPointer);
-            } else {
-                $q->select('uid')
-                    ->from($tableName);
+                $q->orderBy((string)$transPointer);
             }
-
             $rows = $q->execute()->fetchAll();
             foreach ($rows as $row) {
-                $this->updateIndex($key, $configuration['tableName'], (int)$row['uid']);
+                $this->updateIndex($key, $tableName, (int)$row['uid']);
             }
         }
 
@@ -85,14 +89,13 @@ class IndexerService extends AbstractService
      */
     public function reindex(string $configurationKey, string $tableName, int $uid)
     {
-        $dispatcher = GeneralUtility::makeInstance(Dispatcher::class);
-        $dispatcher->dispatch(__CLASS__, __FUNCTION__ . 'Pre', [$configurationKey, $tableName, $uid, $this]);
+        $this->signalSlot->dispatch(__CLASS__, __FUNCTION__ . 'Pre', [$configurationKey, $tableName, $uid, $this]);
 
         $this->removeInvalidConfigurationIndex();
         $this->removeInvalidRecordIndex($tableName);
         $this->updateIndex($configurationKey, $tableName, $uid);
 
-        $dispatcher->dispatch(__CLASS__, __FUNCTION__ . 'Post', [$configurationKey, $tableName, $uid, $this]);
+        $this->signalSlot->dispatch(__CLASS__, __FUNCTION__ . 'Post', [$configurationKey, $tableName, $uid, $this]);
     }
 
     /**
@@ -155,12 +158,7 @@ class IndexerService extends AbstractService
      */
     protected function updateIndex(string $configurationKey, string $tableName, int $uid)
     {
-        /** @var $preparationService IndexPreparationService */
-        static $preparationService = null;
-        if (null === $preparationService) {
-            $preparationService = GeneralUtility::makeInstance(IndexPreparationService::class);
-        }
-        $neededItems = $preparationService->prepareIndex($configurationKey, $tableName, $uid);
+        $neededItems = $this->preparationService->prepareIndex($configurationKey, $tableName, $uid);
         $this->insertAndUpdateNeededItems($neededItems, $tableName, $uid);
     }
 
@@ -178,10 +176,12 @@ class IndexerService extends AbstractService
         $q->getRestrictions()
             ->removeAll()
             ->add(GeneralUtility::makeInstance(DeletedRestriction::class));
-        $q->resetQueryParts();
         $q->select('*')
             ->from(self::TABLE_NAME)
-            ->where($q->expr()->eq('foreign_table', $q->quote($tableName)), $q->expr()->eq('foreign_uid', $uid));
+            ->where(
+                $q->expr()->eq('foreign_table', $q->createNamedParameter($tableName)),
+                $q->expr()->eq('foreign_uid', $q->createNamedParameter($uid, \PDO::PARAM_INT))
+            );
 
         return $q->execute();
     }
@@ -195,23 +195,18 @@ class IndexerService extends AbstractService
      */
     protected function insertAndUpdateNeededItems(array $neededItems, string $tableName, int $uid)
     {
-        $databaseConnection = HelperUtility::getDatabaseConnection($tableName);
+        $databaseConnection = HelperUtility::getDatabaseConnection(self::TABLE_NAME);
         $currentItems = $this->getCurrentItems($tableName, $uid)->fetchAll();
 
         $this->signalSlot->dispatch(__CLASS__, __FUNCTION__ . 'Pre', [$neededItems, $tableName, $uid]);
 
         foreach ($neededItems as $neededKey => $neededItem) {
-            $remove = false;
             foreach ($currentItems as $currentKey => $currentItem) {
                 if (ArrayUtility::isEqualArray($neededItem, $currentItem)) {
-                    $remove = true;
                     unset($neededItems[$neededKey], $currentItems[$currentKey]);
 
                     break;
                 }
-            }
-            if ($remove) {
-                continue;
             }
         }
         foreach ($currentItems as $item) {
@@ -242,7 +237,7 @@ class IndexerService extends AbstractService
 
         $rows = $q->execute()->fetchAll();
 
-        $q->resetQueryParts()->resetRestrictions();
+        $q = HelperUtility::getDatabaseConnection(self::TABLE_NAME)->createQueryBuilder();
         $q->delete(self::TABLE_NAME)
             ->where(
                 $q->expr()->eq('foreign_table', $q->createNamedParameter($tableName))

--- a/Classes/Service/Url/SlugService.php
+++ b/Classes/Service/Url/SlugService.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HDNET\Calendarize\Service\Url;
+
+use HDNET\Calendarize\Event\BaseSlugGenerationEvent;
+use HDNET\Calendarize\Event\SlugSuffixGenerationEvent;
+use HDNET\Calendarize\Features\SpeakingUrlInterface;
+use HDNET\Calendarize\Utility\ConfigurationUtility;
+use HDNET\Calendarize\Utility\EventUtility;
+use HDNET\Calendarize\Utility\ExtensionConfigurationUtility;
+use Psr\EventDispatcher\EventDispatcherInterface;
+use TYPO3\CMS\Core\DataHandling\Model\RecordStateFactory;
+use TYPO3\CMS\Core\DataHandling\SlugHelper;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\DomainObject\DomainObjectInterface;
+
+class SlugService extends \HDNET\Calendarize\Service\AbstractService
+{
+    protected const TABLE_NAME = 'tx_calendarize_domain_model_index';
+    protected const SLUG_NAME = 'slug';
+
+    /**
+     * @var SlugHelper
+     */
+    protected $slugHelper;
+
+    /**
+     * @var RecordStateFactory
+     */
+    protected $stateFactory;
+
+    /**
+     * @var EventDispatcherInterface
+     */
+    protected $eventDispatcher;
+
+    /**
+     * @var bool
+     */
+    protected $useDate;
+
+    public function __construct(EventDispatcherInterface $eventDispatcher)
+    {
+        $this->eventDispatcher = $eventDispatcher;
+        $this->slugHelper = GeneralUtility::makeInstance(
+            SlugHelper::class,
+            self::TABLE_NAME,
+            self::SLUG_NAME,
+            $GLOBALS['TCA'][self::TABLE_NAME]['columns'][self::SLUG_NAME]['config']
+        );
+        $this->stateFactory = RecordStateFactory::forName(self::TABLE_NAME);
+
+        $this->useDate = !(bool)ConfigurationUtility::get('disableDateInSpeakingUrl');
+    }
+
+    /**
+     * Generate a slug for the record and add specific suffixes to each index,
+     * e.g. spacex-falcon-9-crew-2-20210422.
+     *
+     * @param string $uniqueRegisterKey
+     * @param array  $record
+     * @param array  $neededItems
+     *
+     * @return array
+     */
+    public function generateSlugForItems(string $uniqueRegisterKey, array $record, array $neededItems): array
+    {
+        if (empty($neededItems)) {
+            return [];
+        }
+
+        // Get domain model
+        $configuration = ExtensionConfigurationUtility::get($uniqueRegisterKey);
+        /** @var DomainObjectInterface $model */
+        $model = EventUtility::getOriginalRecordByConfiguration($configuration, $record['uid']);
+
+        $baseSlug = $this->generateBaseSlug($uniqueRegisterKey, $record, $model);
+
+        return $this->generateSlugSuffix($uniqueRegisterKey, $baseSlug, $neededItems);
+    }
+
+    /**
+     * Generate a base slug for the record.
+     *
+     * @param string                $uniqueRegisterKey
+     * @param array                 $record
+     * @param DomainObjectInterface $model
+     *
+     * @return string
+     */
+    protected function generateBaseSlug(string $uniqueRegisterKey, array $record, DomainObjectInterface $model): string
+    {
+        // If the model has a speaking url use it
+        if ($model instanceof SpeakingUrlInterface) {
+            $baseSlug = $model->getRealUrlAliasBase();
+        }
+
+        // Multiple fallbacks
+        if (empty($baseSlug)) {
+            $baseSlug = $record['slug']
+                ?? $record['path_segment']
+                ?? "$uniqueRegisterKey-{$record['uid']}";
+        }
+
+        $baseSlug = $this->slugHelper->sanitize($baseSlug);
+
+        return $this->eventDispatcher->dispatch(new BaseSlugGenerationEvent(
+            $uniqueRegisterKey,
+            $model,
+            $record,
+            $baseSlug
+        ))->getBaseSlug();
+    }
+
+    /**
+     * Generate a suffix for all items, e.g. test-20201103.
+     *
+     * @param string $uniqueRegisterKey
+     * @param string $base
+     * @param array  $items
+     *
+     * @return array
+     */
+    protected function generateSlugSuffix(string $uniqueRegisterKey, string $base, array $items): array
+    {
+        $addFields = [];
+        foreach ($items as $key => $item) {
+            $indexSlug = $base;
+
+            // Skip date on single event
+            if ($this->useDate && 1 !== \count($items)) {
+                $indexSlug .= '-' . str_replace('-', '', $item['start_date']);
+            }
+
+            $indexSlug = $this->slugHelper->sanitize($indexSlug);
+            $addFields[$key]['slug'] = $this->eventDispatcher->dispatch(new SlugSuffixGenerationEvent(
+                $uniqueRegisterKey,
+                $item,
+                $indexSlug
+            ))->getSlug();
+        }
+
+        return $addFields;
+    }
+
+    /**
+     * Process the record and make the slug unique in the table, e.g. adds a suffix on duplicate.
+     *
+     * @param array $recordData
+     *
+     * @return string
+     */
+    public function makeSlugUnique(array $recordData): string
+    {
+        // Create RecordState and generate slug
+        $state = $this->stateFactory->fromArray(
+            $recordData,
+            $recordData['pid'],
+            $recordData['uid'] ?? ''
+        );
+        /* @noinspection PhpUnhandledExceptionInspection */
+        return $this->slugHelper->buildSlugForUniqueInTable($recordData['slug'], $state);
+    }
+}

--- a/Classes/Utility/ArrayUtility.php
+++ b/Classes/Utility/ArrayUtility.php
@@ -19,12 +19,16 @@ class ArrayUtility
      *
      * @param array $neededItem
      * @param array $currentItem
+     * @param array $ignoredKeys
      *
      * @return bool
      */
-    public static function isEqualArray(array $neededItem, array $currentItem)
+    public static function isEqualArray(array $neededItem, array $currentItem, array $ignoredKeys = []): bool
     {
         foreach ($neededItem as $key => $value) {
+            if (\in_array($key, $ignoredKeys, true)) {
+                continue;
+            }
             if (MathUtility::canBeInterpretedAsInteger($value)) {
                 if ((int)$value !== (int)$currentItem[$key]) {
                     return false;

--- a/Configuration/TCA/tx_calendarize_domain_model_index.php
+++ b/Configuration/TCA/tx_calendarize_domain_model_index.php
@@ -82,6 +82,12 @@ $custom = [
                 'readOnly' => '1',
             ],
         ],
+        'slug' => [
+            'config' => [
+                'eval' => 'unique',
+                'prependSlash' => false,
+            ],
+        ],
     ],
 ];
 

--- a/Configuration/Yaml/RouteEnhancers.yaml
+++ b/Configuration/Yaml/RouteEnhancers.yaml
@@ -45,11 +45,11 @@ routeEnhancers:
     type: Plugin
     namespace: 'tx_calendarize_calendar'
     routePath: '/{calendarize_event_label}/{index}'
-    requirements:
-      index: '.*'
     aspects:
       index:
-        type: EventMapper
+        type: PersistedAliasMapper
+        tableName: tx_calendarize_domain_model_index
+        routeFieldName: slug
       calendarize_event_label:
         type: LocaleModifier
         default: 'event'


### PR DESCRIPTION
This adds the slug generation process described in #540.

First of all in the IndexPreperation a slug is generated for each item (without conflict handling).
Directly before inserting the slug is made unique e.g. the conflict handler of the core is called.

The generation process is put inside SlugService and generates the slug for all items.
For this a base slug for the record is generated and an individual suffix for each index is added.
For the base slug and individual slug seperate PSR-14 events are called.

The indexing process ignores changes if only tstamp or crdate differ.
In addition some cleanup is done inside the services.

To generate slugs for existing records the `calendarize:reindex` needs to be run!

Does the implementation structure make sence and are the PSR-14 events a "good way" to keep this expandable (and make sense)???
Any Feedback is welcome.
