### PR TITLE
Replace pagination widget in backend module

### DIFF
--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -666,6 +666,27 @@
 			<trans-unit id="search.text">
 				<source>Text</source>
 			</trans-unit>
+			<trans-unit id="pagination.previous" resname="pagination.previous">
+				<source>previous</source>
+			</trans-unit>
+			<trans-unit id="pagination.next" resname="pagination.next">
+				<source>next</source>
+			</trans-unit>
+			<trans-unit id="pagination.first" resname="pagination.first">
+				<source>first</source>
+			</trans-unit>
+			<trans-unit id="pagination.last" resname="pagination.last">
+				<source>last</source>
+			</trans-unit>
+			<trans-unit id="pagination.records" resname="pagination.records">
+				<source>Items</source>
+			</trans-unit>
+			<trans-unit id="pagination.page" resname="pagination.page">
+				<source>Page</source>
+			</trans-unit>
+			<trans-unit id="pagination.refresh" resname="pagination.refresh">
+				<source>Refresh</source>
+			</trans-unit>
 		</body>
 	</file>
 </xliff>

--- a/Resources/Private/Partials/Backend/List.html
+++ b/Resources/Private/Partials/Backend/List.html
@@ -1,44 +1,43 @@
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers" data-namespace-typo3-fluid="true">
 
-<f:be.widget.paginate objects="{indices}" as="indexBlock" configuration="{itemsPerPage: 50, insertBelow: 1}">
-	<div class="table-fit">
-		<table class="table table-striped table-hover">
-			<thead>
-			<tr>
-				<th class="col-title">
-					Title
-				</th>
-				<th class="col-title">
-					Date
-				</th>
-				<th class="col-title">
-					Type
-				</th>
-				<th class="col-title">
-					Language
-				</th>
-				<th class="col-title">
-					ID
-				</th>
-				<th class="col-title">
-					Action
-				</th>
-			</tr>
-			</thead>
-			<tbody>
-			<f:for each="{indexBlock}" as="index">
-				<f:render partial="Backend/Row" arguments="{index: index}"/>
-			</f:for>
-			</tbody>
-			<tfoot>
-			<tr>
-				<td colspan="5">
-					<f:count subject="{indices}"/>
-					items
-				</td>
-			</tr>
-			</tfoot>
-		</table>
-	</div>
-</f:be.widget.paginate>
+<div class="table-fit">
+	<table class="table table-striped table-hover">
+		<thead>
+		<tr>
+			<th class="col-title">
+				Title
+			</th>
+			<th class="col-title">
+				Date
+			</th>
+			<th class="col-title">
+				Type
+			</th>
+			<th class="col-title">
+				Language
+			</th>
+			<th class="col-title">
+				ID
+			</th>
+			<th class="col-title">
+				Action
+			</th>
+		</tr>
+		</thead>
+		<tbody>
+		<f:for each="{paginator.paginatedItems}" as="index">
+			<f:render partial="Backend/Row" arguments="{index: index}"/>
+		</f:for>
+		</tbody>
+		<tfoot>
+		<tr>
+			<td colspan="5">
+				{totalAmount}
+				items
+			</td>
+		</tr>
+		</tfoot>
+	</table>
+</div>
+<f:render partial="Backend/Pagination" arguments="{paginator:paginator, pagination:pagination}" />
 </html>

--- a/Resources/Private/Partials/Backend/Pagination.html
+++ b/Resources/Private/Partials/Backend/Pagination.html
@@ -1,0 +1,89 @@
+<nav class="pagination-wrap">
+	<ul class="pagination">
+		<f:if condition="{pagination.previousPageNumber} && {pagination.previousPageNumber} >= {pagination.firstPageNumber}">
+			<f:then>
+				<li class="page-item">
+					<a href="{f:uri.action(arguments:{currentPage: 1})}" title="{f:translate(key:'pagination.first')}" class="page-link">
+						<core:icon identifier="actions-view-paging-first" />
+					</a>
+				</li>
+				<li class="page-item">
+					<a href="{f:uri.action(arguments:{currentPage: pagination.previousPageNumber})}" title="{f:translate(key:'pagination.previous')}" class="page-link">
+						<core:icon identifier="actions-view-paging-previous" />
+					</a>
+				</li>
+			</f:then>
+			<f:else>
+				<li class="page-item disabled">
+                    <span class="page-link">
+                        <core:icon identifier="actions-view-paging-first" />
+                    </span>
+				</li>
+				<li class="page-item disabled">
+                    <span class="page-link">
+                        <core:icon identifier="actions-view-paging-previous" />
+                    </span>
+				</li>
+			</f:else>
+		</f:if>
+		<li class="page-item">
+            <span class="page-link">
+                <f:translate key="pagination.records" /> {pagination.startRecordNumber} - {pagination.endRecordNumber}
+            </span>
+		</li>
+		<li class="page-item">
+            <span class="page-link">
+                <f:translate key="pagination.page" />
+                <form style="display:inline;"
+											data-global-event="submit"
+											data-action-navigate="$form=~s/$value/"
+											data-navigate-value="{f:uri.action(arguments:'{currentPage: \'$[value]\'}')}"
+											data-value-selector="input[name='paginator-target-page']">
+                    <input
+											min="{pagination.firstPageNumber}"
+											max="{pagination.lastPageNumber}"
+											data-number-of-pages="{paginator.numberOfPages}"
+											name="paginator-target-page"
+											class="form-control form-control-sm paginator-input"
+											size="5"
+											value="{paginator.currentPageNumber}"
+											type="number"
+										/>
+                </form>
+                / {pagination.lastPageNumber}
+            </span>
+		</li>
+
+		<f:if condition="{pagination.nextPageNumber} && {pagination.nextPageNumber} <= {pagination.lastPageNumber}">
+			<f:then>
+				<li class="page-item">
+					<a href="{f:uri.action(arguments:{currentPage: pagination.nextPageNumber})}" title="{f:translate(key:'pagination.next')}" class="page-link">
+						<core:icon identifier="actions-view-paging-next" />
+					</a>
+				</li>
+				<li class="page-item">
+					<a href="{f:uri.action(arguments:{currentPage: pagination.lastPageNumber})}" title="{f:translate(key:'pagination.last')}" class="page-link">
+						<core:icon identifier="actions-view-paging-last" />
+					</a>
+				</li>
+			</f:then>
+			<f:else>
+				<li class="page-item disabled">
+                    <span class="page-link">
+                        <core:icon identifier="actions-view-paging-next" />
+                    </span>
+				</li>
+				<li class="page-item disabled">
+                    <span class="page-link">
+                        <core:icon identifier="actions-view-paging-last" />
+                    </span>
+				</li>
+			</f:else>
+		</f:if>
+		<li class="page-item">
+			<a href="{f:uri.action(arguments:{currentPage: paginator.currentPageNumber})}" title="{f:translate(key:'pagination.refresh')}" class="page-link">
+				<core:icon identifier="actions-refresh" />
+			</a>
+		</li>
+	</ul>
+</nav>

--- a/Resources/Private/Partials/Backend/Row.html
+++ b/Resources/Private/Partials/Backend/Row.html
@@ -21,11 +21,13 @@
 	<td>
 		{index.foreignUid}
 	</td>
-	<td>
-		<be:link.editRecord class="btn btn-default" uid="{index.foreignUid}" table="{index.configuration.tableName}"
-												returnUrl="{f:be.uri(route: 'web_CalendarizeCalendarize')}">
-			<core:icon identifier="actions-document-open"/>
-		</be:link.editRecord>
+	<td class="col-control">
+		<div class="btn-group" role="group">
+			<be:link.editRecord class="btn btn-default" uid="{index.foreignUid}" table="{index.configuration.tableName}"
+													returnUrl="{f:be.uri(route: 'web_CalendarizeCalendarize')}">
+				<core:icon identifier="actions-open"/>
+			</be:link.editRecord>
+		</div>
 	</td>
 </tr>
 </html>

--- a/Resources/Private/Templates/Backend/List.html
+++ b/Resources/Private/Templates/Backend/List.html
@@ -1,7 +1,6 @@
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
 			xmlns:be="http://typo3.org/ns/TYPO3/CMS/Backend/ViewHelpers"
 			xmlns:core="http://typo3.org/ns/TYPO3/CMS/Core/ViewHelpers"
-			xmlns:c="http://typo3.org/ns/HDNET/Calendarize/ViewHelpers"
 			data-namespace-typo3-fluid="true">
 
 <f:layout name="Backend"/>
@@ -13,7 +12,7 @@
 	<f:flashMessages/>
 
 	<fieldset class="form-group border">
-		<f:form action="option" object="{options}" name="options">
+		<f:form action="list" object="{options}" name="options">
 
 			<f:comment>
 			<div class="form-group">

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -55,7 +55,7 @@ $categoryRegistry->add('calendarize', 'tx_calendarize_domain_model_pluginconfigu
         'web',
         'calendarize',
         '',
-        ['Backend' => 'list,option'],
+        ['Backend' => 'list'],
         [
             // Additional configuration
             'access' => 'user, group',


### PR DESCRIPTION
Instead of using the be.widget.paginate, the events are now paginated
with the new pagination API.
Additionally the option action is now part of the list action.

Custom be templates need to be updated!

Related #542
Fixes #535