### PR TITLE
Feature/event slug

### DIFF
--- a/Classes/Domain/Model/Event.php
+++ b/Classes/Domain/Model/Event.php
@@ -132,6 +132,14 @@ class Event extends AbstractModel implements FeedInterface, SpeakingUrlInterface
     protected $hidden = false;
 
     /**
+     * Slug.
+     *
+     * @var string
+     * @DatabaseField("string")
+     */
+    protected $slug = '';
+
+    /**
      * Build up the object.
      */
     public function __construct()
@@ -343,7 +351,7 @@ class Event extends AbstractModel implements FeedInterface, SpeakingUrlInterface
      */
     public function getRealUrlAliasBase(): string
     {
-        return (string)$this->getTitle();
+        return $this->getSlug() ?: $this->getTitle();
     }
 
     /**
@@ -540,5 +548,21 @@ class Event extends AbstractModel implements FeedInterface, SpeakingUrlInterface
     public function setOrganizerLink($organizerLink)
     {
         $this->organizerLink = $organizerLink;
+    }
+
+    /**
+     * @return string
+     */
+    public function getSlug(): string
+    {
+        return $this->slug;
+    }
+
+    /**
+     * @param string $slug
+     */
+    public function setSlug(string $slug): void
+    {
+        $this->slug = $slug;
     }
 }

--- a/Classes/Routing/Aspect/EventMapper.php
+++ b/Classes/Routing/Aspect/EventMapper.php
@@ -19,10 +19,20 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * EventMapper.
+ *
+ * @deprecated
  */
 class EventMapper implements PersistedMappableAspectInterface, StaticMappableAspectInterface, SiteLanguageAwareInterface
 {
     use SiteLanguageAwareTrait;
+
+    public function __construct()
+    {
+        @trigger_error(
+            'EventMapper will be removed. Use the slug field with PersistedAliasMapper instead.',
+            \E_USER_DEPRECATED
+        );
+    }
 
     /**
      * @param string $value

--- a/Classes/Service/Url/AbstractUrl.php
+++ b/Classes/Service/Url/AbstractUrl.php
@@ -18,6 +18,8 @@ use TYPO3\CMS\Extbase\Object\ObjectManager;
 
 /**
  * AbstractUrl.
+ *
+ * @deprecated
  */
 abstract class AbstractUrl extends AbstractService
 {

--- a/Classes/Service/Url/Typo3Route.php
+++ b/Classes/Service/Url/Typo3Route.php
@@ -7,12 +7,13 @@ declare(strict_types=1);
 
 namespace HDNET\Calendarize\Service\Url;
 
-use HDNET\Calendarize\Domain\Model\Index;
 use TYPO3\CMS\Core\DataHandling\SlugHelper;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Typo3Route.
+ *
+ * @deprecated
  */
 class Typo3Route extends AbstractUrl
 {

--- a/Classes/Updates/PopulateEventSlugs.php
+++ b/Classes/Updates/PopulateEventSlugs.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HDNET\Calendarize\Updates;
+
+use HDNET\Calendarize\Service\IndexerService;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Database\Query\Restriction\DeletedRestriction;
+use TYPO3\CMS\Core\DataHandling\Model\RecordStateFactory;
+use TYPO3\CMS\Core\DataHandling\SlugHelper;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Install\Updates\DatabaseUpdatedPrerequisite;
+
+class PopulateEventSlugs extends AbstractUpdate
+{
+    protected $title = 'Introduce URL parts ("slugs") to calendarize event model';
+
+    protected $description = 'Updates slug field of EXT:calendarize event records and runs a reindex';
+
+    /**
+     * @var string
+     */
+    protected $table = 'tx_calendarize_domain_model_event';
+
+    /**
+     * @var string
+     */
+    protected $fieldName = 'slug';
+
+    /**
+     * @var IndexerService
+     */
+    protected $indexerService;
+
+    /**
+     * PupulateEventSlugs constructor.
+     */
+    public function __construct()
+    {
+        $this->indexerService = GeneralUtility::makeInstance(IndexerService::class);
+    }
+
+    public function getIdentifier(): string
+    {
+        return 'calendarize_populateEventSlugs';
+    }
+
+    public function executeUpdate(): bool
+    {
+        $this->populateSlugs($this->table, $this->fieldName);
+        $this->indexerService->reindexAll();
+
+        return true;
+    }
+
+    /**
+     * Populate the slug fields in the table using SlugHelper.
+     *
+     * @param string $table
+     * @param string $field
+     */
+    public function populateSlugs(string $table, string $field): void
+    {
+        $connection = GeneralUtility::makeInstance(ConnectionPool::class)->getConnectionForTable($table);
+        $queryBuilder = $connection->createQueryBuilder();
+        $queryBuilder->getRestrictions()->removeAll()->add(GeneralUtility::makeInstance(DeletedRestriction::class));
+        $statement = $queryBuilder
+            ->select('*')
+            ->from($table)
+            ->where(
+                $queryBuilder->expr()->orX(
+                    $queryBuilder->expr()->eq($field, $queryBuilder->createNamedParameter('')),
+                    $queryBuilder->expr()->isNull($field)
+                )
+            )
+            ->execute();
+
+        $fieldConfig = $GLOBALS['TCA'][$table]['columns'][$field]['config'];
+        $evalInfo = !empty($fieldConfig['eval']) ? GeneralUtility::trimExplode(',', $fieldConfig['eval'], true) : [];
+        $hasToBeUnique = \in_array('unique', $evalInfo, true);
+        $hasToBeUniqueInSite = \in_array('uniqueInSite', $evalInfo, true);
+        $hasToBeUniqueInPid = \in_array('uniqueInPid', $evalInfo, true);
+        /** @var SlugHelper $slugHelper */
+        $slugHelper = GeneralUtility::makeInstance(SlugHelper::class, $table, $field, $fieldConfig);
+        while ($record = $statement->fetch()) {
+            $recordId = (int)$record['uid'];
+            $pid = (int)$record['pid'];
+            $slug = $slugHelper->generate($record, $pid);
+
+            $state = RecordStateFactory::forName($table)
+                ->fromArray($record, $pid, $recordId);
+            if ($hasToBeUnique && !$slugHelper->isUniqueInTable($slug, $state)) {
+                $slug = $slugHelper->buildSlugForUniqueInTable($slug, $state);
+            }
+            if ($hasToBeUniqueInSite && !$slugHelper->isUniqueInSite($slug, $state)) {
+                $slug = $slugHelper->buildSlugForUniqueInSite($slug, $state);
+            }
+            if ($hasToBeUniqueInPid && !$slugHelper->isUniqueInPid($slug, $state)) {
+                $slug = $slugHelper->buildSlugForUniqueInPid($slug, $state);
+            }
+
+            $connection->update(
+                $table,
+                [$field => $slug],
+                ['uid' => $recordId]
+            );
+        }
+    }
+
+    /**
+     * Check if any slug field in the table has an empty value.
+     *
+     * @param string $table
+     * @param string $field
+     *
+     * @return bool
+     */
+    protected function checkEmptySlug(string $table, string $field): bool
+    {
+        $connectionPool = GeneralUtility::makeInstance(ConnectionPool::class);
+        $queryBuilder = $connectionPool->getQueryBuilderForTable($table);
+        $queryBuilder->getRestrictions()->removeAll()->add(GeneralUtility::makeInstance(DeletedRestriction::class));
+
+        $numberOfEntries = $queryBuilder
+            ->count('uid')
+            ->from($table)
+            ->where(
+                $queryBuilder->expr()->orX(
+                    $queryBuilder->expr()->eq($field, $queryBuilder->createNamedParameter('')),
+                    $queryBuilder->expr()->isNull($field)
+                )
+            )
+            ->execute()
+            ->fetchColumn();
+
+        return $numberOfEntries > 0;
+    }
+
+    public function updateNecessary(): bool
+    {
+        return $this->checkEmptySlug($this->table, $this->fieldName);
+    }
+
+    /**
+     * @return string[] All new fields and tables must exist
+     */
+    public function getPrerequisites(): array
+    {
+        return [
+            DatabaseUpdatedPrerequisite::class,
+        ];
+    }
+}

--- a/Configuration/TCA/tx_calendarize_domain_model_event.php
+++ b/Configuration/TCA/tx_calendarize_domain_model_event.php
@@ -85,6 +85,18 @@ $custom = [
                 ],
             ],
         ],
+        'slug' => [
+            'config' => [
+                'prependSlash' => false,
+                'generatorOptions' => [
+                    'fields' => ['title'],
+                    'replacements' => [
+                        '/' => '-',
+                    ],
+                ],
+                'eval' => 'unique',
+            ],
+        ],
     ],
 ];
 

--- a/Documentation/AdministratorManual/UrlRewrite/Index.rst
+++ b/Documentation/AdministratorManual/UrlRewrite/Index.rst
@@ -16,7 +16,6 @@ This is the reason why there are services to generate speaking URLs of index IDs
 
   \HDNET\Calendarize\Features\SpeakingUrlInterface
 
-Please use the EventMapper for URL rewrite options of the index.
 You can just load the RouteEnhancers of the extension.
 
 .. code-block:: yaml

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -612,6 +612,9 @@
 			<trans-unit id="tx_calendarize_domain_model_event.title">
 				<source>Title</source>
 			</trans-unit>
+			<trans-unit id="tx_calendarize_domain_model_event.slug">
+				<source>URL segment</source>
+			</trans-unit>
 			<trans-unit id="tx_calendarize_domain_model_index">
 				<source>Index</source>
 			</trans-unit>

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -10,7 +10,7 @@ timeShift = 0
 # cat=basic/enable; type=boolean; label=Disable date in speaking URL:Disable the date in the speaking URL generation
 disableDateInSpeakingUrl = 0
 
-# cat=basic/enable; type=boolean; label=Add index in speaking URL:Add the Index UID at the end of the generated URI of the even to avoid conflicts
+# cat=basic/enable; type=boolean; label=[DEPRECATED][EventMapper] Add index in speaking URL:Add the Index UID at the end of the generated URI of the even to avoid conflicts
 addIndexInSpeakingUrl = 0
 
 # cat=basic/int+; type=int+; label=Till Days:Maximum of (future) days for which indices should be created (per default based on start date, if till days is relative is true then based on the current day). The frequency limit per item is still active, make sure to set the value high enough. It is also possible to leave this blank and set the value per configuration item.

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -65,6 +65,7 @@ foreach ($icons as $identifier => $path) {
 }
 
 if (class_exists(\TYPO3\CMS\Core\Routing\Aspect\PersistedPatternMapper::class)) {
+    /** @deprecated */
     $GLOBALS['TYPO3_CONF_VARS']['SYS']['routing']['aspects']['EventMapper'] = \HDNET\Calendarize\Routing\Aspect\EventMapper::class;
 }
 

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -45,6 +45,7 @@ $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['ext/install']['update']['calendarize_
 $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['ext/install']['update']['calendarize_newIncludeExcludeStructure'] = \HDNET\Calendarize\Updates\NewIncludeExcludeStructureUpdate::class;
 $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['ext/install']['update']['calendarize_dateField'] = \HDNET\Calendarize\Updates\DateFieldUpdate::class;
 $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['ext/install']['update']['calendarize_tillDateField'] = \HDNET\Calendarize\Updates\TillDateFieldUpdate::class;
+$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['ext/install']['update']['calendarize_populateEventSlugs'] = \HDNET\Calendarize\Updates\PopulateEventSlugs::class;
 
 $GLOBALS['TYPO3_CONF_VARS']['FE']['typolinkBuilder']['record'] = \HDNET\Calendarize\Typolink\DatabaseRecordLinkBuilder::class;
 


### PR DESCRIPTION
Add slug field to calendarize events and a corresponding upgrade wizard.
The wizard is based on [typo3/sysext/install/Classes/Updates/PopulatePageSlugs](typo3/sysext/install/Classes/Updates/PopulatePageSlugs.php).

In addition the old EventMapper and further classes are marked as deprecated.

Related #540 