### PR TITLE
Replace pagination widget in FE list

### DIFF
--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -46,6 +46,7 @@ plugin.tx_calendarize {
 			100 = {$plugin.tx_calendarize.view.layoutRootPath}
 		}
 
+        // Deprecated: remove after Typo3 > 10
 		widget {
 			TYPO3\CMS\Fluid\ViewHelpers\Widget\PaginateViewHelper {
 				templateRootPath = EXT:calendarize/Resources/Private/Templates/

--- a/Resources/Private/Partials/List.html
+++ b/Resources/Private/Partials/List.html
@@ -11,18 +11,14 @@
 				</f:for>
 			</f:then>
 			<f:else>
-				<f:if condition="{settings.paginateConfiguration}">
-					<f:then>
-						<f:widget.paginate objects="{indices}" as="paginatedIndices"
-															 configuration="{settings.paginateConfiguration}">
-							<f:for each="{paginatedIndices}" as="index">
-								<f:render partial="{index.configuration.partialIdentifier}/ListItem" arguments="{index: index}"/>
-							</f:for>
-						</f:widget.paginate>
-					</f:then>
-					<f:else>
-						You have to include the static typoscript to get the paginateConfiguration for list views
-					</f:else>
+				<f:if condition="{settings.paginateConfiguration.insertAbove -> f:or(alternative:0)}">
+					<f:render partial="Pagination" arguments="{pagination: pagination.pagination, paginator: pagination.paginator}" />
+				</f:if>
+				<f:for each="{pagination.paginator.paginatedItems}" as="index">
+					<f:render partial="{index.configuration.partialIdentifier}/ListItem" arguments="{index: index}" />
+				</f:for>
+				<f:if condition="{settings.paginateConfiguration.insertBelow -> f:or(alternative:1)}">
+					<f:render partial="Pagination" arguments="{pagination: pagination.pagination, paginator: pagination.paginator}" />
 				</f:if>
 			</f:else>
 		</f:if>

--- a/Resources/Private/Partials/Pagination.html
+++ b/Resources/Private/Partials/Pagination.html
@@ -1,0 +1,57 @@
+<ul class="f3-widget-paginator">
+	<f:if condition="{pagination.previousPageNumber} && {pagination.previousPageNumber} >= {pagination.firstPageNumber}">
+		<f:then>
+			<f:comment>
+				<li class="first">
+					<a href="{f:uri.action(action:actionName, arguments:{currentPage: 1})}" title="{f:translate(key:'pagination.first')}">
+						<i class="material-icons">first_page</i>
+					</a>
+				</li>
+			</f:comment>
+			<li class="previous">
+				<a href="{f:uri.action(action:actionName, arguments:{currentPage: pagination.previousPageNumber})}" title="{f:translate(key:'pagination.previous')}">
+					{f:translate(key:'widget.pagination.previous', extensionName: 'fluid')}
+				</a>
+			</li>
+		</f:then>
+		<f:else>
+			<f:comment>
+				<li class="disabled"><span><i class="material-icons">first_page</i></span></li>
+				<li class="disabled"><span>{f:translate(key:'widget.pagination.previous', extensionName: 'fluid')}</span></li>
+			</f:comment>
+		</f:else>
+	</f:if>
+	<f:if condition="{pagination.hasLessPages}">
+		<li>…</li>
+	</f:if>
+	<f:for each="{pagination.allPageNumbers}" as="page">
+		<li class="{f:if(condition: '{page} == {paginator.currentPageNumber}', then:'current')}">
+			<a href="{f:uri.action(action:actionName, arguments:{currentPage: page})}">{page}</a>
+		</li>
+	</f:for>
+	<f:if condition="{pagination.hasMorePages}">
+		<li>…</li>
+	</f:if>
+	<f:if condition="{pagination.nextPageNumber} && {pagination.nextPageNumber} <= {pagination.lastPageNumber}">
+		<f:then>
+			<li class="next">
+				<a href="{f:uri.action(action:actionName, arguments:{currentPage: pagination.nextPageNumber})}" title="{f:translate(key:'pagination.next')}">
+					{f:translate(key:'widget.pagination.next', extensionName: 'fluid')}
+				</a>
+			</li>
+			<f:comment>
+				<li class="last">
+					<a href="{f:uri.action(action:actionName, arguments:{currentPage: pagination.lastPageNumber})}" title="{f:translate(key:'pagination.last')}">
+						last
+					</a>
+				</li>
+			</f:comment>
+		</f:then>
+		<f:else>
+			<f:comment>
+				<li class="disabled"><span>{f:translate(key:'widget.pagination.next', extensionName: 'fluid')}</span></li>
+				<li class="disabled"><span>last page</span></li>
+			</f:comment>
+		</f:else>
+	</f:if>
+</ul>

--- a/Resources/Private/Templates/Calendar/Latest.html
+++ b/Resources/Private/Templates/Calendar/Latest.html
@@ -2,6 +2,6 @@
 
 <f:section name="Main">
 
-	<f:render partial="List" arguments="{settings: settings, indices: indices, contentObject:contentObject}" />
+	<f:render partial="List" arguments="{settings: settings, indices: indices, contentObject:contentObject, pagination: pagination}" />
 
 </f:section>

--- a/Resources/Private/Templates/Calendar/List.html
+++ b/Resources/Private/Templates/Calendar/List.html
@@ -10,6 +10,6 @@
 		<f:link.action action="list" format="ics" arguments="{hmac: extended.pluginHmac}">iCal</f:link.action>
 	</f:comment>
 
-	<f:render partial="List" arguments="{settings: settings, indices: indices, contentObject:contentObject}" />
+	<f:render partial="List" arguments="{settings: settings, indices: indices, contentObject:contentObject, pagination: pagination}" />
 
 </f:section>

--- a/Resources/Private/Templates/Calendar/Past.html
+++ b/Resources/Private/Templates/Calendar/Past.html
@@ -12,6 +12,6 @@
 		<f:link.action action="list" format="atom" arguments="{hmac: extended.pluginHmac}">Atom</f:link.action>
 		<f:link.action action="list" format="ics" arguments="{hmac: extended.pluginHmac}">iCal</f:link.action>
 	</f:comment>
-	<f:render partial="List" arguments="{settings: settings, indices: indices,contentObject:contentObject}" />
+	<f:render partial="List" arguments="{settings: settings, indices: indices,contentObject:contentObject, pagination: pagination}" />
 
 </f:section>

--- a/Resources/Private/Templates/Calendar/Result.html
+++ b/Resources/Private/Templates/Calendar/Result.html
@@ -1,5 +1,5 @@
 <f:layout name="Default" />
 
 <f:section name="Main">
-	<f:render partial="List" arguments="{settings: settings, indices: indices, searchParameter: searchParameter, searchMode: searchMode,contentObject:contentObject}" />
+	<f:render partial="List" arguments="{settings: settings, indices: indices, searchParameter: searchParameter, searchMode: searchMode,contentObject:contentObject, pagination: pagination}" />
 </f:section>

--- a/Resources/Private/Templates/Calendar/Shortcut.html
+++ b/Resources/Private/Templates/Calendar/Shortcut.html
@@ -4,6 +4,6 @@
 
 	<f:flashMessages />
 
-	<f:render partial="List" arguments="{settings: settings, indices: indices,contentObject:contentObject}" />
+	<f:render partial="List" arguments="{settings: settings, indices: indices,contentObject:contentObject, pagination: pagination}" />
 
 </f:section>

--- a/Resources/Private/Templates/ViewHelpers/Widget/Paginate/Index.html
+++ b/Resources/Private/Templates/ViewHelpers/Widget/Paginate/Index.html
@@ -1,3 +1,4 @@
+<f:comment>DEPRECATED: Use new pagination logic; remove file after Typo3 > 10</f:comment>
 <f:if condition="{configuration.insertAbove}">
 	<f:render section="paginator" arguments="{pagination: pagination, configuration: configuration}" />
 </f:if>

--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,8 @@
 		"issues": "https://github.com/lochmueller/calendarize/issues"
 	},
 	"suggest": {
-		"brotkrueml/schema": "Output of structured data information for better Google Search Result User Experience"
+		"brotkrueml/schema": "Output of structured data information for better Google Search Result User Experience",
+		"georgringer/numbered-pagination": "Pagination with reduced amount of pages"
 	},
 	"require-dev": {
 		"typo3/testing-framework": "^6.3",


### PR DESCRIPTION
Instead of using the widget.paginate, the indices are now paginated
with the new pagination API.
To limit the amount of pages, georgringer/numbered-pagination is
suggested.
Old templates with widget.paginate should still continue to work
(in TYPO3 10 or until removed).

Related: #542