### PR TITLE
Use slug as uid in ics

### DIFF
--- a/Resources/Private/Partials/Feed/Item.ics
+++ b/Resources/Private/Partials/Feed/Item.ics
@@ -1,7 +1,7 @@
 {namespace c=HDNET\Calendarize\ViewHelpers}
 <f:if condition="{index}">
 BEGIN:VEVENT
-UID:calendarize-{index.uid}
+UID:calendarize-{index.slug}
 DTSTAMP:{f:if(condition: index.tstamp, then: index.tstamp, else: 'now') -> c:dateTime.formatUtcDate(format: 'Ymd\THis\Z')}
 <f:if condition="{index.allDay}">
     <f:then>


### PR DESCRIPTION
Use the slug for the ics UID, since it is lasts longer than the uid.