### PR TITLE
[FEATURE] Make backend date and time formats configurable

### DIFF
--- a/Classes/Controller/BackendController.php
+++ b/Classes/Controller/BackendController.php
@@ -26,8 +26,8 @@ class BackendController extends AbstractController
      */
     public function listAction(OptionRequest $options = null, int $currentPage = 1)
     {
-        $this->settings['timeFormat'] = 'H:i';
-        $this->settings['dateFormat'] = 'd.m.Y';
+        $this->settings['timeFormat'] = $GLOBALS['TYPO3_CONF_VARS']['SYS']['ddmmyy'] ?? 'd-m-y';
+        $this->settings['dateFormat'] = $GLOBALS['TYPO3_CONF_VARS']['SYS']['hhmm'] ?? 'H:i';
 
         if (null === $options) {
             $options = $this->getOptions();

--- a/Classes/Domain/Model/Event.php
+++ b/Classes/Domain/Model/Event.php
@@ -16,6 +16,7 @@ use HDNET\Calendarize\Features\KeSearchIndexInterface;
 use HDNET\Calendarize\Features\SpeakingUrlInterface;
 use TYPO3\CMS\Extbase\Domain\Model\Category;
 use TYPO3\CMS\Extbase\Persistence\ObjectStorage;
+use TYPO3\CMS\Backend\Utility\BackendUtility;
 
 /**
  * Event (Default) for the calendarize function.
@@ -403,8 +404,7 @@ class Event extends AbstractModel implements FeedInterface, SpeakingUrlInterface
      */
     public function getKeSearchTitle(Index $index): string
     {
-        return (string)$this->getTitle() . ' - ' . $index->getStartDate()
-                ->format('d.m.Y');
+        return (string)$this->getTitle() . ' - ' . BackendUtility::date($index->getStartDate());
     }
 
     /**

--- a/Classes/Form/Element/CalendarizeInfoElement.php
+++ b/Classes/Form/Element/CalendarizeInfoElement.php
@@ -48,12 +48,12 @@ class CalendarizeInfoElement extends AbstractFormElement
             if (!($event['start_date'] instanceof \DateTimeInterface)) {
                 $event['start_date'] = new \DateTime($event['start_date']);
             }
-            $startDate = strftime(DateTimeUtility::FORMAT_DATE_BACKEND, (int)$event['start_date']->getTimestamp());
+            $startDate = BackendUtility::date((int)$event['start_date']->getTimestamp());
 
             if (!($event['end_date'] instanceof \DateTimeInterface)) {
                 $event['end_date'] = new \DateTime($event['end_date']);
             }
-            $endDate = strftime(DateTimeUtility::FORMAT_DATE_BACKEND, (int)$event['end_date']->getTimestamp());
+            $endDate = BackendUtility::date((int)$event['end_date']->getTimestamp());
             $entry = $startDate . ' - ' . $endDate;
             if (!$event['all_day']) {
                 $start = BackendUtility::time($event['start_time'] % DateTimeUtility::SECONDS_DAY, false);

--- a/Classes/Hooks/CmsLayout.php
+++ b/Classes/Hooks/CmsLayout.php
@@ -112,11 +112,11 @@ class CmsLayout extends AbstractHook
         } else {
             $overrideStartDate = (int)$this->flexFormService->get('settings.overrideStartdate', 'main');
             if ($overrideStartDate) {
-                $this->layoutService->addRow(TranslateUtility::get('override.startdate'), date('d.m.y H:i', $overrideStartDate));
+                $this->layoutService->addRow(TranslateUtility::get('override.startdate'), BackendUtility::datetime($overrideStartDate));
             }
             $overrideEndDate = (int)$this->flexFormService->get('settings.overrideEnddate', 'main');
             if ($overrideEndDate) {
-                $this->layoutService->addRow(TranslateUtility::get('override.enddate'), date('d.m.y H:i', $overrideEndDate));
+                $this->layoutService->addRow(TranslateUtility::get('override.enddate'), BackendUtility::datetime($overrideEndDate));
             }
         }
 

--- a/Classes/Service/TcaInformation.php
+++ b/Classes/Service/TcaInformation.php
@@ -79,12 +79,12 @@ class TcaInformation extends AbstractService
             if (!($event['start_date'] instanceof \DateTimeInterface)) {
                 $event['start_date'] = new \DateTime($event['start_date']);
             }
-            $startDate = strftime(DateTimeUtility::FORMAT_DATE_BACKEND, (int)$event['start_date']->getTimestamp());
+            $startDate = BackendUtility::date((int)$event['start_date']->getTimestamp());
 
             if (!($event['end_date'] instanceof \DateTimeInterface)) {
                 $event['end_date'] = new \DateTime($event['end_date']);
             }
-            $endDate = strftime(DateTimeUtility::FORMAT_DATE_BACKEND, (int)$event['end_date']->getTimestamp());
+            $endDate = BackendUtility::date((int)$event['end_date']->getTimestamp());
             $entry = $startDate . ' - ' . $endDate;
             if (!$event['all_day']) {
                 $start = BackendUtility::time($event['start_time'] % DateTimeUtility::SECONDS_DAY, false);

--- a/Classes/Service/TcaService.php
+++ b/Classes/Service/TcaService.php
@@ -147,8 +147,8 @@ class TcaService extends AbstractService
         $title = '';
         if ($row['start_date']) {
             try {
-                $dateStart = strftime(DateTimeUtility::FORMAT_DATE_BACKEND, (new \DateTime($row['start_date']))->getTimestamp());
-                $dateEnd = strftime(DateTimeUtility::FORMAT_DATE_BACKEND, (new \DateTime($row['end_date'] ?: $row['start_date']))->getTimestamp());
+                $dateStart = BackendUtility::date((new \DateTime($row['start_date']))->getTimestamp());
+                $dateEnd = BackendUtility::date((new \DateTime($row['end_date'] ?: $row['start_date']))->getTimestamp());
                 $title .= $dateStart;
                 if ($dateStart !== $dateEnd) {
                     $title .= ' - ' . $dateEnd;

--- a/Classes/Utility/DateTimeUtility.php
+++ b/Classes/Utility/DateTimeUtility.php
@@ -55,11 +55,6 @@ class DateTimeUtility
     const SECONDS_DECADE = 315360000;
 
     /**
-     * Format date (Backend).
-     */
-    const FORMAT_DATE_BACKEND = '%a %d.%m.%Y';
-
-    /**
      * Convert a Week/Year combination to a DateTime of the first day of week.
      *
      * @param int $week


### PR DESCRIPTION
Make backend date and time formats configurable. Where needed, fallbacks match TYPO3 default configuration.

Resolves #558 