### PR TITLE
Move subtypes_excludelist back to ext_tables

### DIFF
--- a/Configuration/TCA/Overrides/tt_content.php
+++ b/Configuration/TCA/Overrides/tt_content.php
@@ -12,6 +12,3 @@ defined('TYPO3') or exit();
 if (!\HDNET\Calendarize\Utility\ConfigurationUtility::get('disableDefaultEvent')) {
     \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addToInsertRecords('tx_calendarize_domain_model_event');
 }
-
-// Exclude "pages" and obsolete fields
-$GLOBALS['TCA']['tt_content']['types']['list']['subtypes_excludelist']['calendarize_calendar'] = 'recursive,select_key,pages';

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -30,4 +30,9 @@ defined('TYPO3') or exit();
             'navigationComponentId' => '',
         ]
     );
+
+    // Exclude "pages" and obsolete fields
+    // Stored here instead of Overrides/tt_content, otherwise it is overwritten by autoloader
+    $GLOBALS['TCA']['tt_content']['types']['list']['subtypes_excludelist']['calendarize_calendar'] = 'recursive,select_key,pages';
+
 })();


### PR DESCRIPTION
Normally subtypes_excludelist is defined in the TCA Overrides/tt_content.
However the value was overwritten by a autoloader call afterwards.
This partially undoes the change from #562 /
c7db3b07ff9cd1094953540516052ee2194edefb