### PR TITLE
Fix backend date in keSearch, BE module

### DIFF
--- a/Classes/Controller/BackendController.php
+++ b/Classes/Controller/BackendController.php
@@ -26,8 +26,8 @@ class BackendController extends AbstractController
      */
     public function listAction(OptionRequest $options = null, int $currentPage = 1)
     {
-        $this->settings['timeFormat'] = $GLOBALS['TYPO3_CONF_VARS']['SYS']['ddmmyy'] ?? 'd-m-y';
-        $this->settings['dateFormat'] = $GLOBALS['TYPO3_CONF_VARS']['SYS']['hhmm'] ?? 'H:i';
+        $this->settings['timeFormat'] = $GLOBALS['TYPO3_CONF_VARS']['SYS']['hhmm'] ?? 'H:i';
+        $this->settings['dateFormat'] = $GLOBALS['TYPO3_CONF_VARS']['SYS']['ddmmyy'] ?? 'd-m-y';
 
         if (null === $options) {
             $options = $this->getOptions();

--- a/Classes/Domain/Model/Event.php
+++ b/Classes/Domain/Model/Event.php
@@ -14,9 +14,9 @@ use HDNET\Autoloader\Annotation\SmartExclude;
 use HDNET\Calendarize\Features\FeedInterface;
 use HDNET\Calendarize\Features\KeSearchIndexInterface;
 use HDNET\Calendarize\Features\SpeakingUrlInterface;
+use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Extbase\Domain\Model\Category;
 use TYPO3\CMS\Extbase\Persistence\ObjectStorage;
-use TYPO3\CMS\Backend\Utility\BackendUtility;
 
 /**
  * Event (Default) for the calendarize function.
@@ -404,7 +404,7 @@ class Event extends AbstractModel implements FeedInterface, SpeakingUrlInterface
      */
     public function getKeSearchTitle(Index $index): string
     {
-        return (string)$this->getTitle() . ' - ' . BackendUtility::date($index->getStartDate());
+        return (string)$this->getTitle() . ' - ' . BackendUtility::date($index->getStartDate()->getTimestamp());
     }
 
     /**


### PR DESCRIPTION
Related #561 / 4b3e56d567172f584bf474868e8ad4c9466e402d

@phvt 

Fixes some minor mistakses.

The usage of BackendUtility (BE) inside getKeSearchTitle is conceptionally wrong, since the title is displayed in the FE. The usage of the `settings.dateFormat` would better fit here, however it is too much work (e.g. injecting configurationManager, use ConfigurationManagerInterface, ...). So I will leaf it as is.