### PR TITLE
Fix #573 - request object not defined in CLI

### DIFF
--- a/Classes/Utility/EventUtility.php
+++ b/Classes/Utility/EventUtility.php
@@ -8,6 +8,8 @@ declare(strict_types=1);
 namespace HDNET\Calendarize\Utility;
 
 use HDNET\Calendarize\Domain\Model\PluginConfiguration;
+use Psr\Http\Message\ServerRequestInterface;
+use TYPO3\CMS\Core\Core\Environment;
 use TYPO3\CMS\Core\Http\ApplicationType;
 
 /**
@@ -32,7 +34,10 @@ class EventUtility
         }
 
         $query = HelperUtility::getQuery($modelName);
-        if (ApplicationType::fromRequest($GLOBALS['TYPO3_REQUEST'])->isBackend()) {
+        if (Environment::isCli()
+            || ($GLOBALS['TYPO3_REQUEST'] ?? null) instanceof ServerRequestInterface
+            && ApplicationType::fromRequest($GLOBALS['TYPO3_REQUEST'])->isBackend()
+        ) {
             $query->getQuerySettings()->setIgnoreEnableFields(true);
         }
 

--- a/Classes/Utility/TranslateUtility.php
+++ b/Classes/Utility/TranslateUtility.php
@@ -7,7 +7,6 @@ declare(strict_types=1);
 
 namespace HDNET\Calendarize\Utility;
 
-use TYPO3\CMS\Core\Http\ApplicationType;
 use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
 
 /**
@@ -24,7 +23,7 @@ class TranslateUtility
      */
     public static function get($key)
     {
-        if (ApplicationType::fromRequest($GLOBALS['TYPO3_REQUEST'])->isFrontend() && !\is_object($GLOBALS['TSFE'])) {
+        if (TYPO3_MODE === 'FE' && !\is_object($GLOBALS['TSFE'])) {
             // check wrong eID context. Do not call "LocalizationUtility::translate" in eID context, if there is no
             // valid TypoScriptFrontendController. Skip this call by returning just the $key!
             return $key;


### PR DESCRIPTION
The `$GLOBALS['TYPO3_REQUEST']` was not defined in CLI commands,
e.g. upgrade wizards. This adds extra checks.
Revert change in TranslateUtility due to unknown behavior.

Fixes #573 