### PR TITLE
Bugfix: Cast pageUid to int, resolving #579

### DIFF
--- a/Classes/Controller/BackendController.php
+++ b/Classes/Controller/BackendController.php
@@ -131,7 +131,7 @@ class BackendController extends AbstractController
 
         $typeLocations = [];
         foreach ($this->indexRepository->findDifferentTypesAndLocations() as $entry) {
-            $pageId = $entry['pid'];
+            $pageId = (int)$entry['pid'];
             if ($this->isPageAllowed($pageId, $mountPoints)) {
                 $typeLocations[$entry['foreign_table']][$pageId] = $entry['unique_register_key'];
             }


### PR DESCRIPTION
Resolves an issue with page ids being passed as strings to the isPageAllowed Method in the Backend, as suggested in #579 