### PR TITLE
[BUGFIX] add times until the maxLimit is reached resolves #583

### DIFF
--- a/Classes/Service/TimeTable/TimeTimeTable.php
+++ b/Classes/Service/TimeTable/TimeTimeTable.php
@@ -199,7 +199,8 @@ class TimeTimeTable extends AbstractTimeTable
         $amountCounter = $configuration->getCounterAmount();
         $maxLimit = $this->getFrequencyLimitPerItem();
         $lastLoop = $baseEntry;
-        for ($i = 0; $i < $maxLimit && (0 === $amountCounter || $i < $amountCounter); ++$i) {
+        $loopEntriesAdded = 0;
+        for ($i = 0; $loopEntriesAdded < $maxLimit && (0 === $amountCounter || $i < $amountCounter); ++$i) {
             $loopEntry = $this->createNextLoopEntry($lastLoop, $frequencyIncrement);
 
             if ($tillDateConfiguration['tillDate'] instanceof \DateTimeInterface && $loopEntry['start_date'] > $tillDateConfiguration['tillDate']) {
@@ -213,6 +214,7 @@ class TimeTimeTable extends AbstractTimeTable
             }
 
             $times[$this->calculateEntryKey($loopEntry)] = $loopEntry;
+            ++$loopEntriesAdded;
         }
     }
 
@@ -293,8 +295,9 @@ class TimeTimeTable extends AbstractTimeTable
         $amountCounter = $configuration->getCounterAmount();
         $maxLimit = $this->getFrequencyLimitPerItem();
         $lastLoop = $baseEntry;
+        $loopEntriesAdded = 0;
         $intervalCounter = $configuration->getCounterInterval() <= 1 ? 1 : $configuration->getCounterInterval();
-        for ($i = 0; $i < $maxLimit && (0 === $amountCounter || $i < $amountCounter); ++$i) {
+        for ($i = 0; $loopEntriesAdded < $maxLimit && (0 === $amountCounter || $i < $amountCounter); ++$i) {
             $loopEntry = $lastLoop;
 
             $dateTime = false;
@@ -334,6 +337,7 @@ class TimeTimeTable extends AbstractTimeTable
             }
 
             $times[$this->calculateEntryKey($loopEntry)] = $loopEntry;
+            ++$loopEntriesAdded;
         }
     }
 


### PR DESCRIPTION
Instead of using `$i < $maxLimit` as a condition to limit the amount of indices persisted to the database i added a new variable `$loopEntriesAdded`. Each time a `$loopEntry` is added to `$times` `$loopEntriesAdded` is increased by one.

This fixes  the issue "Till Days Relative" in combination with "Till Days" and "Till Days Past" (#583).
For records that do not use this feature nothing should change.