### PR TITLE
Fix count in BE with fresh installation

### DIFF
--- a/Classes/Controller/BackendController.php
+++ b/Classes/Controller/BackendController.php
@@ -55,7 +55,7 @@ class BackendController extends AbstractController
             'options' => $options,
             'paginator' => $paginator,
             'pagination' => $pagination,
-            'totalAmount' => $indices->count(),
+            'totalAmount' => \count($indices),
         ]);
     }
 


### PR DESCRIPTION
Error message: Call to a member function on array

@typomike Please create a issue for future problems - instead of commenting a commit itself

See https://github.com/lochmueller/calendarize/commit/c5f6ebf8d5a58867dff1fbc00ea9c2b534739134#commitcomment-54081797
> after installing 10.2.1 with Typo3 10.4.17 i get this message (see attachement)
> ![Bildschirmfoto 2021-07-28 um 12 27 31](https://user-images.githubusercontent.com/3757657/127307634-44aa73c8-4bff-4b58-a4dc-9845c14ab4b1.png)