### PR TITLE
take (optional) title and class attribute into account when creating links

### DIFF
--- a/Classes/ViewHelpers/Link/AbstractActionViewHelper.php
+++ b/Classes/ViewHelpers/Link/AbstractActionViewHelper.php
@@ -52,6 +52,14 @@ class AbstractActionViewHelper extends AbstractLinkViewHelper
                 $this->pluginName
             );
 
+        if ('' != $this->arguments['title']) {
+            $this->tag->addAttribute('title', $this->arguments['title']);
+        }
+
+        if ('' != $this->arguments['class']) {
+            $this->tag->addAttribute('class', $this->arguments['class']);
+        }
+
         if ('' !== $this->lastHref) {
             $this->tag->addAttribute('href', $this->lastHref);
             $this->tag->setContent($this->renderChildren());
@@ -60,7 +68,6 @@ class AbstractActionViewHelper extends AbstractLinkViewHelper
         } else {
             $result = $this->renderChildren();
         }
-
         return $result;
     }
 }


### PR DESCRIPTION
Hi there,

I'm using `calendarize` and wanted to pass `title` and `class` attributes to anchors.
This PR takes this two optional parameters into account when creating a link.

**before**
![image](https://user-images.githubusercontent.com/2580723/130960916-66d53e7c-8d6f-414c-8163-499b7601516e.png)

**after**
![image](https://user-images.githubusercontent.com/2580723/130960784-11decf34-a02a-4cb0-a100-69f4457507b7.png)

**usage**
simply add the `title` and `class` you want to have for the anchor.
```
<c:link.year title="Test title" 
             class="btn btn-outline-info btn-sm"
             pageUid="{settings.yearPid}"
             date="{date -> c:dateTime.modify(modification: 'first day of last year')}"
             section="c{contentObject.uid}">
        &lt;
</c:link.year>
```