### PR TITLE
Use description in dashboard widget content

### DIFF
--- a/Configuration/Services.php
+++ b/Configuration/Services.php
@@ -46,7 +46,7 @@ return function (ContainerConfigurator $configurator) {
             ->arg('$view', new Reference('dashboard.views.widget'))
             ->arg('$dataProvider', new Reference(IndexAmountDataProvider::class))
             ->arg('$options', [
-                'title' => TranslateUtility::getLll('calendarizeIndexAmount.title'),
+                'title' => TranslateUtility::getLll('calendarizeIndexAmount.description'),
                 'icon' => 'calendarize-extension',
             ])->tag('dashboard.widget', [
                 'identifier' => 'calendarizeIndexAmount',


### PR DESCRIPTION
By using the description here the text in dashboard widget title and dashboard widget content are no longer the same.

Before:
![grafik](https://user-images.githubusercontent.com/367315/132338883-a594f18f-e4b9-4082-bf27-5873d9f45835.png)

After:
![grafik](https://user-images.githubusercontent.com/367315/132338858-13ace89d-aa15-409e-a70f-0df7550ad41b.png)
