### PR TITLE
Fix #613, overlays configuration uid with data of parent's workspace uid

### DIFF
--- a/Classes/Service/IndexPreparationService.php
+++ b/Classes/Service/IndexPreparationService.php
@@ -59,7 +59,7 @@ class IndexPreparationService extends AbstractService
         $neededItems = [];
         if ($configurations) {
             $timeTableService = GeneralUtility::makeInstance(TimeTableService::class);
-            $neededItems = $timeTableService->getTimeTablesByConfigurationIds($configurations);
+            $neededItems = $timeTableService->getTimeTablesByConfigurationIds($configurations, $rawRecord['t3ver_wsid']);
             foreach ($neededItems as $key => $record) {
                 $record['foreign_table'] = $tableName;
                 $record['foreign_uid'] = $uid;

--- a/Classes/Service/TimeTableService.php
+++ b/Classes/Service/TimeTableService.php
@@ -15,7 +15,6 @@ use HDNET\Calendarize\Service\TimeTable\AbstractTimeTable;
 use HDNET\Calendarize\Utility\DateTimeUtility;
 use HDNET\Calendarize\Utility\HelperUtility;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
-use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Core\Messaging\FlashMessage;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Object\ObjectManager;
@@ -29,7 +28,7 @@ class TimeTableService extends AbstractService
      * Build the timetable for the given configuration matrix (sorted).
      *
      * @param array $ids
-     * @param int $workspace
+     * @param int   $workspace
      *
      * @return array
      */

--- a/Classes/Service/TimeTableService.php
+++ b/Classes/Service/TimeTableService.php
@@ -29,20 +29,15 @@ class TimeTableService extends AbstractService
      * Build the timetable for the given configuration matrix (sorted).
      *
      * @param array $ids
+     * @param int $workspace
      *
      * @return array
      */
-    public function getTimeTablesByConfigurationIds(array $ids)
+    public function getTimeTablesByConfigurationIds(array $ids, $workspace)
     {
         $timeTable = [];
         if (!$ids) {
             return $timeTable;
-        }
-
-        try {
-            $workspace = (int)GeneralUtility::makeInstance(Context::class)->getPropertyFromAspect('workspace', 'id');
-        } catch (\Exception $exception) {
-            $workspace = 0;
         }
 
         $configRepository = GeneralUtility::makeInstance(ObjectManager::class)->get(ConfigurationRepository::class);
@@ -51,7 +46,7 @@ class TimeTableService extends AbstractService
                 $row = BackendUtility::getRecord('tx_calendarize_domain_model_configuration', $configurationUid);
                 BackendUtility::workspaceOL('tx_calendarize_domain_model_configuration', $row, $workspace);
                 if (isset($row['_ORIG_uid'])) {
-                    //    $configurationUid = (int)$row['_ORIG_uid'];
+                    $configurationUid = (int)$row['_ORIG_uid'];
                 }
             }
 


### PR DESCRIPTION
It overlays the configuration uid with the workspace version.

Not the uid of the current workspace is used, but the workspace version of the event.

So, when saving a event in workspace in BE, the live-index will be created with live-configuration-data and the workspace-index is created with its workspace-configuration-data.