### PR TITLE
fixes #630, linkhandler-links do not link text if linked event has no index

### DIFF
--- a/Classes/Typolink/DatabaseRecordLinkBuilder.php
+++ b/Classes/Typolink/DatabaseRecordLinkBuilder.php
@@ -31,9 +31,10 @@ class DatabaseRecordLinkBuilder extends \TYPO3\CMS\Frontend\Typolink\DatabaseRec
 
             $indexUid = $this->getIndexForEventUid($linkDetails['identifier'], $eventId);
 
-            if(!$indexUid){
+            if (!$indexUid) {
                 $conf['parameter'] = 0;
                 $linkDetails = [];
+
                 return parent::build($linkDetails, $linkText, $target, $conf);
             }
 


### PR DESCRIPTION
Linkhandler-links do not link text to the no-event-found-view. They are left as pure text.