### PR TITLE
Fix check for $overrideEndDateRelative

### DIFF
--- a/Classes/Controller/CalendarController.php
+++ b/Classes/Controller/CalendarController.php
@@ -659,7 +659,7 @@ class CalendarController extends AbstractCompatibilityController
                 $overrideStartDate = $relativeDate->getTimestamp();
                 $overrideEndDate = 0;
                 $overrideEndDateRelative = trim($this->settings['overrideEndRelative']);
-                if ('' !== $overrideStartDateRelative) {
+                if ('' !== $overrideEndDateRelative) {
                     try {
                         $relativeDate->modify($overrideEndDateRelative);
                         $overrideEndDate = $relativeDate->getTimestamp();


### PR DESCRIPTION
This will fix a possible warning in case $overrideEndDateRelative is empty. The check for $overrideStartDateRelative seems wrong as it can't be empty. Some lines before $overrideStartDateRelative gets a default value if empty.