### PR TITLE
Add defaultController in routeEnhancers

### DIFF
--- a/Configuration/Yaml/RouteEnhancers.yaml
+++ b/Configuration/Yaml/RouteEnhancers.yaml
@@ -22,6 +22,7 @@ routeEnhancers:
       - routePath: '/{calendarize_page_label}/{currentPage}'
         _controller: 'Calendar::list'
 
+    defaultController: 'Calendar::list'
 #    requirements:
       # Specify kind of parameters, if the aspects are not used.
       # year: '\d{4}'


### PR DESCRIPTION
Related: #641

This adds a default controller to the routeEnhancers.
It fixes paging for the listAction.
The problem with the pagination of the resultAction still persists.