### PR TITLE
Fix #645 - Catch unknown timezone in ICalDissect

### DIFF
--- a/Resources/Private/Php/ICalDissect/src/JMBTechnologyLimited/ICalDissect/ICalEvent.php
+++ b/Resources/Private/Php/ICalDissect/src/JMBTechnologyLimited/ICalDissect/ICalEvent.php
@@ -135,8 +135,10 @@ class ICalEvent
 
             // Is Timezone in Keyword Properties?
             if (substr($keywordProperties, 0, 5) == 'TZID=') {
-                $timeZone = new \DateTimeZone(substr($keywordProperties, 5));
-                $out->setTimezone($timeZone);
+                try {
+                    $timeZone = new \DateTimeZone(substr($keywordProperties, 5));
+                    $out->setTimezone($timeZone);
+                } catch (\Exception $e) {}
             }
         }
         $out->setDate((int)$date[1], (int)$date[2], (int)$date[3]);

--- a/Tests/Unit/Ical/ICalEventTest.php
+++ b/Tests/Unit/Ical/ICalEventTest.php
@@ -329,6 +329,29 @@ END:VCALENDAR
         self::assertFalse($event->isAllDay());
     }
 
+    public function testUnknownTimezone()
+    {
+        $input = 'BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//CalendarizeTest
+BEGIN:VEVENT
+UID:de3e9a87-69ec-43f8-9332-5abe7e04f3ca@example.com
+DTSTAMP:20220107T220312Z
+DTSTART;TZID="Unknown timezone":20220214T123000
+DTEND;TZID="Unknown timezone":20220214T133000
+END:VEVENT
+END:VCALENDAR
+';
+        $event = $this->getEvent($input);
+        self::assertEquals('20220214', $event->getStartDate()->format('Ymd'));
+        self::assertEquals('20220214', $event->getEndDate()->format('Ymd'));
+        // With an unknown timezone we expect the time to be UTC or the server time zone
+        // (depends on the library used, in this case these are the same!)
+        self::assertEquals((12 * 60 + 30) * 60, $event->getStartTime());
+        self::assertEquals((13 * 60 + 30) * 60, $event->getEndTime());
+        self::assertFalse($event->isAllDay());
+    }
+
     public function testAllDayTimezone()
     {
         date_default_timezone_set('America/Los_Angeles');


### PR DESCRIPTION
The `Unknown or bad timezone` exception in **ICalDissect** is now caught.
This may cause some events to be parsed with the wrong timezone if
the timezone is unknown (e.g. Microsoft timezone format).

_Note_: This only affected non-composer installations with ICalDissect. `sabre/vobject` is NOT affected.

```php
Exception : DateTimeZone::__construct(): Unknown or bad timezone ("W. Europe Standard Time")
/Resources/Private/Php/ICalDissect/src/JMBTechnologyLimited/ICalDissect/ICalEvent.php:139
/Resources/Private/Php/ICalDissect/src/JMBTechnologyLimited/ICalDissect/ICalEvent.php:68
/Resources/Private/Php/ICalDissect/src/JMBTechnologyLimited/ICalDissect/ICalParser.php:88
```

Fixes #645