### PR TITLE
Visual and small fixes

### DIFF
--- a/Classes/Domain/Repository/EventRepository.php
+++ b/Classes/Domain/Repository/EventRepository.php
@@ -10,8 +10,6 @@ namespace HDNET\Calendarize\Domain\Repository;
 use HDNET\Calendarize\Domain\Model\Dto\Search;
 use HDNET\Calendarize\Domain\Model\Event;
 use HDNET\Calendarize\Domain\Model\Index;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Extbase\Object\ObjectManager;
 use TYPO3\CMS\Extbase\Persistence\QueryInterface;
 
 /**
@@ -19,6 +17,19 @@ use TYPO3\CMS\Extbase\Persistence\QueryInterface;
  */
 class EventRepository extends AbstractRepository
 {
+    /**
+     * @var IndexRepository
+     */
+    protected $indexRepository;
+
+    /**
+     * @param IndexRepository $indexRepository
+     */
+    public function injectIndexRepository(IndexRepository $indexRepository)
+    {
+        $this->indexRepository = $indexRepository;
+    }
+
     /**
      * Get the IDs of the given search term.
      *
@@ -82,13 +93,10 @@ class EventRepository extends AbstractRepository
             return null;
         }
 
-        /** @var IndexRepository $indexRepository */
-        $indexRepository = GeneralUtility::makeInstance(ObjectManager::class)->get(IndexRepository::class);
-
         try {
-            $result = $indexRepository->findByEventTraversing($event, true, false, 1, QueryInterface::ORDER_ASCENDING);
+            $result = $this->indexRepository->findByEventTraversing($event, true, false, 1, QueryInterface::ORDER_ASCENDING);
             if (empty($result)) {
-                $result = $indexRepository->findByEventTraversing($event, false, true, 1, QueryInterface::ORDER_DESCENDING);
+                $result = $this->indexRepository->findByEventTraversing($event, false, true, 1, QueryInterface::ORDER_DESCENDING);
             }
         } catch (\Exception $ex) {
             return null;

--- a/Classes/EventListener/DefaultEventSearchListener.php
+++ b/Classes/EventListener/DefaultEventSearchListener.php
@@ -6,11 +6,22 @@ use HDNET\Calendarize\Domain\Model\Dto\Search;
 use HDNET\Calendarize\Domain\Repository\EventRepository;
 use HDNET\Calendarize\Event\IndexRepositoryFindBySearchEvent;
 use HDNET\Calendarize\Register;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Extbase\Object\ObjectManager;
 
 class DefaultEventSearchListener
 {
+    /**
+     * @var EventRepository
+     */
+    protected $eventRepository;
+
+    /**
+     * @param EventRepository $eventRepository
+     */
+    public function __construct(EventRepository $eventRepository)
+    {
+        $this->eventRepository = $eventRepository;
+    }
+
     public function __invoke(IndexRepositoryFindBySearchEvent $event)
     {
         if (!\in_array(Register::UNIQUE_REGISTER_KEY, $event->getIndexTypes(), true)) {
@@ -22,9 +33,8 @@ class DefaultEventSearchListener
         if (!$search->isSearch()) {
             return;
         }
-        /** @var EventRepository $eventRepository */
-        $eventRepository = GeneralUtility::makeInstance(ObjectManager::class)->get(EventRepository::class);
-        $searchTermIds = $eventRepository->findBySearch($search);
+
+        $searchTermIds = $this->eventRepository->findBySearch($search);
         // Blocks result (displaying no event) on no search match (empty id array)
         $searchTermIds[] = -1;
 

--- a/Classes/EventListener/DefaultEventSearchListener.php
+++ b/Classes/EventListener/DefaultEventSearchListener.php
@@ -24,12 +24,13 @@ class DefaultEventSearchListener
         }
         /** @var EventRepository $eventRepository */
         $eventRepository = GeneralUtility::makeInstance(ObjectManager::class)->get(EventRepository::class);
-        $searchTermHits = $eventRepository->findBySearch($search);
-        if ($searchTermHits && \count($searchTermHits)) {
-            $indexIds = $event->getIndexIds();
-            $indexIds['tx_calendarize_domain_model_event'] = $searchTermHits;
-            $event->setIndexIds($indexIds);
-        }
+        $searchTermIds = $eventRepository->findBySearch($search);
+        // Blocks result (displaying no event) on no search match (empty id array)
+        $searchTermIds[] = -1;
+
+        $indexIds = $event->getIndexIds();
+        $indexIds['tx_calendarize_domain_model_event'] = $searchTermIds;
+        $event->setIndexIds($indexIds);
     }
 
     protected function getSearchDto(IndexRepositoryFindBySearchEvent $event): Search

--- a/Classes/Hooks/KeSearchIndexer.php
+++ b/Classes/Hooks/KeSearchIndexer.php
@@ -15,7 +15,6 @@ use HDNET\Calendarize\Domain\Repository\IndexRepository;
 use HDNET\Calendarize\Features\KeSearchIndexInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\HttpUtility;
-use TYPO3\CMS\Extbase\Object\ObjectManager;
 
 /**
  * KE Search Indexer.
@@ -24,6 +23,19 @@ use TYPO3\CMS\Extbase\Object\ObjectManager;
  */
 class KeSearchIndexer extends AbstractHook
 {
+    /**
+     * @var IndexRepository
+     */
+    protected $indexRepository;
+
+    /**
+     * @param IndexRepository $indexRepository
+     */
+    public function __construct(IndexRepository $indexRepository)
+    {
+        $this->indexRepository = $indexRepository;
+    }
+
     /**
      * Register the indexer configuration.
      *
@@ -54,11 +66,9 @@ class KeSearchIndexer extends AbstractHook
             return;
         }
 
-        /** @var IndexRepository $indexRepository */
-        $indexRepository = GeneralUtility::makeInstance(ObjectManager::class)->get(IndexRepository::class);
-        $indexRepository->setOverridePageIds(GeneralUtility::intExplode(',', $indexerConfig['sysfolder']));
+        $this->indexRepository->setOverridePageIds(GeneralUtility::intExplode(',', $indexerConfig['sysfolder']));
         $options = new OptionRequest();
-        $indexObjects = $indexRepository->findAllForBackend($options)
+        $indexObjects = $this->indexRepository->findAllForBackend($options)
             ->toArray();
 
         foreach ($indexObjects as $index) {

--- a/Classes/Service/TimeTableService.php
+++ b/Classes/Service/TimeTableService.php
@@ -17,13 +17,25 @@ use HDNET\Calendarize\Utility\HelperUtility;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Core\Messaging\FlashMessage;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Extbase\Object\ObjectManager;
 
 /**
  * Time table builder service.
  */
 class TimeTableService extends AbstractService
 {
+    /**
+     * @var ConfigurationRepository
+     */
+    protected $configurationRepository;
+
+    /**
+     * @param ConfigurationRepository $configurationRepository
+     */
+    public function __construct(ConfigurationRepository $configurationRepository)
+    {
+        $this->configurationRepository = $configurationRepository;
+    }
+
     /**
      * Build the timetable for the given configuration matrix (sorted).
      *
@@ -39,7 +51,6 @@ class TimeTableService extends AbstractService
             return $timeTable;
         }
 
-        $configRepository = GeneralUtility::makeInstance(ObjectManager::class)->get(ConfigurationRepository::class);
         foreach ($ids as $configurationUid) {
             if ($workspace) {
                 $row = BackendUtility::getRecord('tx_calendarize_domain_model_configuration', $configurationUid);
@@ -51,7 +62,7 @@ class TimeTableService extends AbstractService
 
             // Disable Workspace for selection to get also offline versions of configuration
             $GLOBALS['TCA']['tx_calendarize_domain_model_configuration']['ctrl']['versioningWS'] = false;
-            $configuration = $configRepository->findByUid($configurationUid);
+            $configuration = $this->configurationRepository->findByUid($configurationUid);
             $GLOBALS['TCA']['tx_calendarize_domain_model_configuration']['ctrl']['versioningWS'] = true;
             if (!($configuration instanceof Configuration)) {
                 continue;

--- a/Classes/ViewHelpers/IndexTraversingViewHelper.php
+++ b/Classes/ViewHelpers/IndexTraversingViewHelper.php
@@ -9,8 +9,6 @@ namespace HDNET\Calendarize\ViewHelpers;
 
 use HDNET\Calendarize\Domain\Model\Index;
 use HDNET\Calendarize\Domain\Repository\IndexRepository;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Extbase\Object\ObjectManager;
 use TYPO3\CMS\Extbase\Persistence\QueryInterface;
 
 /**
@@ -27,6 +25,19 @@ use TYPO3\CMS\Extbase\Persistence\QueryInterface;
  */
 class IndexTraversingViewHelper extends AbstractViewHelper
 {
+    /**
+     * @var IndexRepository
+     */
+    protected $indexRepository;
+
+    /**
+     * @param IndexRepository $indexRepository
+     */
+    public function injectIndexRepository(IndexRepository $indexRepository)
+    {
+        $this->indexRepository = $indexRepository;
+    }
+
     /**
      * Init arguments.
      */
@@ -48,9 +59,7 @@ class IndexTraversingViewHelper extends AbstractViewHelper
      */
     public function render()
     {
-        $indexRepository = GeneralUtility::makeInstance(ObjectManager::class)->get(IndexRepository::class);
-
-        return $indexRepository->findByTraversing(
+        return $this->indexRepository->findByTraversing(
             $this->arguments['index'],
             $this->arguments['future'],
             $this->arguments['past'],

--- a/Classes/ViewHelpers/IndicesByObjectViewHelper.php
+++ b/Classes/ViewHelpers/IndicesByObjectViewHelper.php
@@ -7,9 +7,7 @@ namespace HDNET\Calendarize\ViewHelpers;
 use HDNET\Calendarize\Domain\Model\Index;
 use HDNET\Calendarize\Domain\Repository\IndexRepository;
 use HDNET\Calendarize\Register;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
-use TYPO3\CMS\Extbase\Object\ObjectManager;
 use TYPO3\CMS\Extbase\Persistence\QueryInterface;
 
 /**
@@ -26,6 +24,19 @@ use TYPO3\CMS\Extbase\Persistence\QueryInterface;
  */
 class IndicesByObjectViewHelper extends AbstractViewHelper
 {
+    /**
+     * @var IndexRepository
+     */
+    protected $indexRepository;
+
+    /**
+     * @param IndexRepository $indexRepository
+     */
+    public function injectIndexRepository(IndexRepository $indexRepository)
+    {
+        $this->indexRepository = $indexRepository;
+    }
+
     /**
      * Init arguments.
      */
@@ -46,8 +57,6 @@ class IndicesByObjectViewHelper extends AbstractViewHelper
      */
     public function render()
     {
-        $indexRepository = GeneralUtility::makeInstance(ObjectManager::class)->get(IndexRepository::class);
-
         /** @var AbstractEntity $object */
         $object = $this->arguments['object'];
 
@@ -67,7 +76,7 @@ class IndicesByObjectViewHelper extends AbstractViewHelper
         $fakeIndex->setForeignTable($config['tableName']);
         $fakeIndex->setForeignUid($object->getUid());
 
-        return $indexRepository->findByTraversing(
+        return $this->indexRepository->findByTraversing(
             $fakeIndex,
             $this->arguments['future'],
             $this->arguments['past'],

--- a/Resources/Private/Templates/Calendar/Detail.html
+++ b/Resources/Private/Templates/Calendar/Detail.html
@@ -1,6 +1,6 @@
 <div xmlns="http://www.w3.org/1999/xhtml" lang="en"
 		 xmlns:f="http://typo3.org/ns/TYPO3/Fluid/ViewHelpers"
-		 xmlns:c="http://typo3.org/ns/HDNET/Calendarize/ViewHelpers">
+>
 
 	<f:layout name="Default"/>
 
@@ -10,10 +10,10 @@
 				<f:render partial="{index.configuration.partialIdentifier}/Detail" arguments="{index: index}"/>
 				<div class="btn-group">
 					<f:if condition="{settings.listPid}">
-						<c:link.list class="btn btn-default">
+						<f:link.page pageUid="{settings.listPid}" class="btn btn-default">
 							<span class="glyphicon glyphicon-arrow-left"></span>
 							<f:translate key="back"/>
-						</c:link.list>
+						</f:link.page>
 					</f:if>
 					<f:link.action action="detail" arguments="{index: index}" format="ics" class="btn btn-default">ICS/iCal
 					</f:link.action>

--- a/Resources/Private/Templates/Calendar/Single.html
+++ b/Resources/Private/Templates/Calendar/Single.html
@@ -9,6 +9,7 @@
 			<c:link.index index="{index}">
 				<f:render partial="{index.configuration.partialIdentifier}/Title" arguments="{index: index}"/>
 			</c:link.index>
+			<br>
 			<!-- e.g. display abstract or list view -->
 		</f:for>
 	</f:section>


### PR DESCRIPTION
Fix details back button

The back button now only links to the page, instead of linking to the
list action without any arguments.
This prevents non-speaking URLs.

---

Add line break after each index in single view

Multiple links in the single view are now listed below each other.

---

Fix search results on no hit

A search term without any indices resulted in all results being shown.
This change always adds an invalid id (-1) so that without any hit, it does not display any indices.

---

Replace objectManager with DI

See TYPO3 deprecation [90803](https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/10.4/Deprecation-90803-DeprecationOfObjectManagergetInExtbaseContext.html)