### PR TITLE
KeSearch fixes/improvements

### DIFF
--- a/Classes/Domain/Repository/IndexRepository.php
+++ b/Classes/Domain/Repository/IndexRepository.php
@@ -100,14 +100,15 @@ class IndexRepository extends AbstractRepository
      * Select indecies for Backend.
      *
      * @param OptionRequest $options
-     * @param limit values to these pages
+     * @param array         $allowedPages
+     * @param bool          $ignoreEnableFields
      *
      * @return array|\TYPO3\CMS\Extbase\Persistence\QueryResultInterface
      */
-    public function findAllForBackend(OptionRequest $options, array $allowedPages = [])
+    public function findAllForBackend(OptionRequest $options, array $allowedPages = [], bool $ignoreEnableFields = true)
     {
         $query = $this->createQuery();
-        $query->getQuerySettings()->setIgnoreEnableFields(true);
+        $query->getQuerySettings()->setIgnoreEnableFields($ignoreEnableFields);
         $query->getQuerySettings()->setRespectSysLanguage(false);
         $query->getQuerySettings()->setLanguageOverlayMode(false);
 

--- a/Classes/Hooks/KeSearchIndexer.php
+++ b/Classes/Hooks/KeSearchIndexer.php
@@ -23,7 +23,7 @@ use TYPO3\CMS\Core\Utility\HttpUtility;
  */
 class KeSearchIndexer extends AbstractHook
 {
-    const KEY = 'calendarize';
+    public const KEY = 'calendarize';
 
     /**
      * Register the indexer configuration.
@@ -57,10 +57,12 @@ class KeSearchIndexer extends AbstractHook
 
         /** @var IndexRepository $indexRepository */
         $indexRepository = GeneralUtility::makeInstance(IndexRepository::class);
-        $indexRepository->setOverridePageIds(GeneralUtility::intExplode(',', $indexerConfig['sysfolder']));
         $options = new OptionRequest();
-        $indexObjects = $indexRepository->findAllForBackend($options)
-            ->toArray();
+        $indexObjects = $indexRepository->findAllForBackend(
+            $options,
+            GeneralUtility::intExplode(',', $indexerConfig['sysfolder']),
+            false
+        )->toArray();
 
         foreach ($indexObjects as $index) {
             /** @var $index Index */

--- a/Classes/Hooks/KeSearchIndexer.php
+++ b/Classes/Hooks/KeSearchIndexer.php
@@ -23,18 +23,6 @@ use TYPO3\CMS\Core\Utility\HttpUtility;
  */
 class KeSearchIndexer extends AbstractHook
 {
-    /**
-     * @var IndexRepository
-     */
-    protected $indexRepository;
-
-    /**
-     * @param IndexRepository $indexRepository
-     */
-    public function __construct(IndexRepository $indexRepository)
-    {
-        $this->indexRepository = $indexRepository;
-    }
 
     /**
      * Register the indexer configuration.
@@ -66,9 +54,11 @@ class KeSearchIndexer extends AbstractHook
             return;
         }
 
-        $this->indexRepository->setOverridePageIds(GeneralUtility::intExplode(',', $indexerConfig['sysfolder']));
+        /** @var IndexRepository $indexRepository */
+        $indexRepository = GeneralUtility::makeInstance(IndexRepository::class);
+        $indexRepository->setOverridePageIds(GeneralUtility::intExplode(',', $indexerConfig['sysfolder']));
         $options = new OptionRequest();
-        $indexObjects = $this->indexRepository->findAllForBackend($options)
+        $indexObjects = $indexRepository->findAllForBackend($options)
             ->toArray();
 
         foreach ($indexObjects as $index) {


### PR DESCRIPTION
Reverts the DI for KeSearchIndexer from c240b34cee83096e5953f0dc280b5c157af76581(#651)

Some cleanups, change from `TeaminmediasPluswerk\KeSearch` to `Tpwd\KeSearch`.

Add option to disable enableFields for BE reuqests.
This prevents KeSearch from indexing hidden indices.
Fixes #619