### PR TITLE
Fix foreign id for workspace only indices

### DIFF
--- a/Classes/Service/IndexPreparationService.php
+++ b/Classes/Service/IndexPreparationService.php
@@ -88,7 +88,7 @@ class IndexPreparationService extends AbstractService
             $item['t3ver_wsid'] = $workspace;
             // Set relation to the original record
             if ($workspace) {
-                $item['foreign_uid'] = $origId ?? (int)$record['uid'];
+                $item['foreign_uid'] = $origId ?: (int)$record['uid'];
             }
 
             return $item;


### PR DESCRIPTION
If an Event only exists in a workspace, the foreign id of the indices is
 now correct and not 0.