### PR TITLE
[BUGFIX] Check for empty originalObject in detail action

### DIFF
--- a/Classes/Controller/CalendarController.php
+++ b/Classes/Controller/CalendarController.php
@@ -505,8 +505,18 @@ class CalendarController extends AbstractCompatibilityController
                 $this->eventExtendedRedirect(__CLASS__, __FUNCTION__ . 'noEvent');
             }
         }
+        $uniqueRegisterKey = $index->getConfiguration()['uniqueRegisterKey'];
+        $originalObject = $index->getOriginalObject();
+        if (!$originalObject) {
+            $this->eventExtendedRedirect(__CLASS__, __FUNCTION__ . 'noEvent');
+        }
 
-        $this->addCacheTags(['calendarize_detail', 'calendarize_index_' . $index->getUid(), 'calendarize_' . lcfirst($index->getConfiguration()['uniqueRegisterKey']) . '_' . $index->getOriginalObject()->getUid()]);
+        $this->addCacheTags(
+            ['calendarize_detail', 'calendarize_index_' . $index->getUid(), 'calendarize_'
+            . lcfirst($uniqueRegisterKey)
+            . '_'
+            . $originalObject->getUid(), ]
+        );
 
         // Meta tags
         if ($index->getOriginalObject() instanceof Event) {


### PR DESCRIPTION
This resolves the problem of an exception being thrown if an event is loaded
on a translated detail view page, but there is no translation for the event.

The exception was thrown if:

- the event did not have a translation
- the detail view was opened via an URL for a translated page (e.g.
/de/detail/slug-for-default-lang)

Related: #655