### PR TITLE
Fix date in configuration title for US timezones

### DIFF
--- a/Classes/Service/TcaService.php
+++ b/Classes/Service/TcaService.php
@@ -147,24 +147,21 @@ class TcaService extends AbstractService
         $title = '';
         if ($row['start_date']) {
             try {
-                $startDateTime = new \DateTime($row['start_date']);
+                $startTimestamp = (new \DateTime($row['start_date']))->getTimestamp();
+                $endTimestamp = (new \DateTime($row['end_date'] ?: $row['start_date']))->getTimestamp();
 
+                // correct date if time string detected
                 if (str_contains($row['start_date'], 'T')) {
-                    $dateStart = BackendUtility::date((new \DateTime(gmdate('Y-m-d', $startDateTime->getTimestamp())))->getTimestamp());
-                } else {
-                    $dateStart = BackendUtility::date($startDateTime->getTimestamp());
+                    $startTimestamp = (new \DateTime(gmdate('Y-m-d', $startTimestamp)))->getTimestamp();
                 }
-
-                $endDateTime = new \DateTime($row['end_date'] ?: $row['start_date']);
 
                 if (str_contains($row['end_date'] ?: $row['start_date'], 'T')) {
-                    $dateEnd = BackendUtility::date((new \DateTime(gmdate('Y-m-d', ($endDateTime)->getTimestamp())))->getTimestamp());
-                } else {
-                    $dateEnd = BackendUtility::date($endDateTime->getTimestamp());
+                    $endTimestamp = (new \DateTime(gmdate('Y-m-d', $endTimestamp)))->getTimestamp();
                 }
 
+                $dateStart = BackendUtility::date($startTimestamp);
+                $dateEnd = BackendUtility::date($endTimestamp);
                 $title .= $dateStart;
-
                 if ($dateStart !== $dateEnd) {
                     $title .= ' - ' . $dateEnd;
                 }

--- a/Classes/Service/TcaService.php
+++ b/Classes/Service/TcaService.php
@@ -147,21 +147,13 @@ class TcaService extends AbstractService
         $title = '';
         if ($row['start_date']) {
             try {
-                if (str_contains($row['start_date'], 'T')) {
-                    $dateStart = BackendUtility::date((new \DateTime($row['start_date']))->getTimestamp() + -1 * ((new \DateTime($row['start_date']))->getOffset()));
-                } else {
-                    $dateStart = BackendUtility::date((new \DateTime($row['start_date']))->getTimestamp());
-                }
+                $startDateTime = new \DateTime($row['start_date']);
+                $dateStart = BackendUtility::date((new \DateTime(gmdate('Y-m-d', $startDateTime->getTimestamp())))->getTimestamp());
 
-                if (str_contains($row['end_date'] ?: $row['start_date'], 'T')) {
-                    $dateEnd = BackendUtility::date((new \DateTime($row['end_date'] ?: $row['start_date']))->getTimestamp() + -1 * ((new \DateTime($row['start_date']))->getOffset()));
-                } else {
-                    $dateEnd = BackendUtility::date((new \DateTime($row['end_date'] ?: $row['start_date']))->getTimestamp());
-                }
+                $endDateTime = new \DateTime($row['end_date'] ?: $row['start_date']);
+                $dateEnd = BackendUtility::date((new \DateTime(gmdate('Y-m-d', ($endDateTime)->getTimestamp())))->getTimestamp());
 
                 $title .= $dateStart;
-
-                // $title .=  ' [' . ($row['start_date']) . ' | ' . date('c', ((new \DateTime($row['start_date']))->getTimestamp() + -1 *  ((new \DateTime($row['start_date']))->getOffset()))) . '] ';
 
                 if ($dateStart !== $dateEnd) {
                     $title .= ' - ' . $dateEnd;

--- a/Classes/Service/TcaService.php
+++ b/Classes/Service/TcaService.php
@@ -148,10 +148,20 @@ class TcaService extends AbstractService
         if ($row['start_date']) {
             try {
                 $startDateTime = new \DateTime($row['start_date']);
-                $dateStart = BackendUtility::date((new \DateTime(gmdate('Y-m-d', $startDateTime->getTimestamp())))->getTimestamp());
+
+                if (str_contains($row['start_date'], 'T')) {
+                    $dateStart = BackendUtility::date((new \DateTime(gmdate('Y-m-d', $startDateTime->getTimestamp())))->getTimestamp());
+                } else {
+                    $dateStart = BackendUtility::date($startDateTime->getTimestamp());
+                }
 
                 $endDateTime = new \DateTime($row['end_date'] ?: $row['start_date']);
-                $dateEnd = BackendUtility::date((new \DateTime(gmdate('Y-m-d', ($endDateTime)->getTimestamp())))->getTimestamp());
+
+                if (str_contains($row['end_date'] ?: $row['start_date'], 'T')) {
+                    $dateEnd = BackendUtility::date((new \DateTime(gmdate('Y-m-d', ($endDateTime)->getTimestamp())))->getTimestamp());
+                } else {
+                    $dateEnd = BackendUtility::date($endDateTime->getTimestamp());
+                }
 
                 $title .= $dateStart;
 

--- a/Classes/Service/TcaService.php
+++ b/Classes/Service/TcaService.php
@@ -147,9 +147,22 @@ class TcaService extends AbstractService
         $title = '';
         if ($row['start_date']) {
             try {
-                $dateStart = BackendUtility::date((new \DateTime($row['start_date']))->getTimestamp());
-                $dateEnd = BackendUtility::date((new \DateTime($row['end_date'] ?: $row['start_date']))->getTimestamp());
+                if (str_contains($row['start_date'], 'T')) {
+                    $dateStart = BackendUtility::date((new \DateTime($row['start_date']))->getTimestamp() + -1 * ((new \DateTime($row['start_date']))->getOffset()));
+                } else {
+                    $dateStart = BackendUtility::date((new \DateTime($row['start_date']))->getTimestamp());
+                }
+
+                if (str_contains($row['end_date'] ?: $row['start_date'], 'T')) {
+                    $dateEnd = BackendUtility::date((new \DateTime($row['end_date'] ?: $row['start_date']))->getTimestamp() + -1 * ((new \DateTime($row['start_date']))->getOffset()));
+                } else {
+                    $dateEnd = BackendUtility::date((new \DateTime($row['end_date'] ?: $row['start_date']))->getTimestamp());
+                }
+
                 $title .= $dateStart;
+
+                // $title .=  ' [' . ($row['start_date']) . ' | ' . date('c', ((new \DateTime($row['start_date']))->getTimestamp() + -1 *  ((new \DateTime($row['start_date']))->getOffset()))) . '] ';
+
                 if ($dateStart !== $dateEnd) {
                     $title .= ' - ' . $dateEnd;
                 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/60153014/153467845-0dd172b5-1be5-4322-bc1d-cc7f510c4e9a.png)

Currently, for US time zones (or anywhere with a negative UTC offset; west of Greenwich and east of the IDL), there is a discrepancy between the date shown in the title of the record, and the actual `start_date` value. Despite being a date-only value, it gets appended a time string and converted from UTC (e.g. for Los Angeles, `2022-02-10` gets turned into `2022-02-09T16:00:00-08:00`). This results in the event being labelled one day in the past. 

This change converts `start_date` values with a time string back to UTC, with a correct date.