### PR TITLE
[BUGFIX] Fix endtime calculation for all day indices

### DIFF
--- a/Classes/Domain/Model/Index.php
+++ b/Classes/Domain/Model/Index.php
@@ -179,6 +179,9 @@ class Index extends AbstractModel
         if (!$this->isAllDay() && $date instanceof \DateTimeInterface) {
             return DateTimeUtility::setSecondsOfDateTime($date, $this->getEndTime());
         }
+        if ($this->isAllDay() && $date instanceof \DateTimeInterface) {
+            return DateTimeUtility::getDayEnd($date);
+        }
 
         return $date;
     }


### PR DESCRIPTION
The "completeEndTime" for indeces of all day events must be set to the
end of the day, not the beginning.

Resolves: #667