### PR TITLE
Default to 0 if start_time/end_time is null

### DIFF
--- a/Classes/Service/TimeTable/TimeTimeTable.php
+++ b/Classes/Service/TimeTable/TimeTimeTable.php
@@ -225,11 +225,11 @@ class TimeTimeTable extends AbstractTimeTable
     {
         // Time modification
         if (str_contains($modification, 'minutes') || str_contains($modification, 'hours')) {
-            $startTime = new \DateTime('@' . $loopEntry['start_time']);
+            $startTime = new \DateTime('@' . ($loopEntry['start_time'] ?? 0));
             $startTime->modify($modification);
             $loopEntry['start_time'] = $startTime->getTimestamp();
 
-            $endTime = new \DateTime('@' . $loopEntry['end_time']);
+            $endTime = new \DateTime('@' . ($loopEntry['end_time'] ?? 0));
             $endTime->modify($modification);
             $loopEntry['end_time'] = $endTime->getTimestamp();
         } else {

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -259,7 +259,7 @@
 				<source>None</source>
 			</trans-unit>
 			<trans-unit id="configuration.frequency.minutely">
-				<source>Every minute</source>
+				<source>Minutely</source>
 			</trans-unit>
 			<trans-unit id="configuration.frequency.hourly">
 				<source>Hourly</source>


### PR DESCRIPTION
Hi Tim,
when setting frequency hours/minute for an all_day event an exception occurs. This patch fixes this.

Also a small change in the "minutely" label because "every minute" is not correct because it is "every X minutes" where X can be 1 or more.