### PR TITLE
relates to #662, fixes indexing after the publishing-process

### DIFF
--- a/Classes/Hooks/ProcessCmdmapClass.php
+++ b/Classes/Hooks/ProcessCmdmapClass.php
@@ -12,6 +12,8 @@ use HDNET\Calendarize\Register;
 use HDNET\Calendarize\Service\IndexerService;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Core\Context\Context;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Database\Query\QueryBuilder;
 use TYPO3\CMS\Core\DataHandling\DataHandler;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
@@ -40,7 +42,21 @@ class ProcessCmdmapClass extends AbstractHook
 
         $register = Register::getRegister();
         foreach ($register as $key => $configuration) {
-            if ($configuration['tableName'] === $table) {
+            if ('version' == $command && 'swap' == $value['action']) {
+                // do nothing with the event itself. The configuration is the last one, which is published
+                if ('tx_calendarize_domain_model_configuration' == $table) {
+                    $parent = $this->findParentEventInThisTable($configuration['tableName'], (int)$uid);
+                    if (\is_array($parent)) {
+                        $parentConfigurations = GeneralUtility::trimExplode(',', $parent['calendarize']);
+                        // we just re-index the last given configuration (this is just a workaround - but indexing of all leads
+                        // to the behaviour, that only the first one is really indexed)
+                        if ($uid == $parentConfigurations[\count($parentConfigurations) - 1]) {
+                            $indexer = GeneralUtility::makeInstance(IndexerService::class);
+                            $indexer->reindex($key, $configuration['tableName'], (int)$parent['uid']);
+                        }
+                    }
+                }
+            } elseif ($configuration['tableName'] === $table) {
                 // the live-uid is given there. But we need the overlayed one for further process
                 if ('delete' === $command && $workspaceId) {
                     $wsOverlay = BackendUtility::getRecordWSOL($table, $uid, '', false);
@@ -53,5 +69,27 @@ class ProcessCmdmapClass extends AbstractHook
                 $indexer->reindex($key, $table, (int)$uid);
             }
         }
+    }
+
+    protected function findParentEventInThisTable($table, $uid)
+    {
+        // there is no calendarize field and we will not find our parent there
+        if ('tx_calendarize_domain_model_configurationgroup' == $table) {
+            return false;
+        }
+
+        /** @var QueryBuilder $queryBuilder */
+        $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getConnectionForTable($table)->createQueryBuilder();
+
+        return $queryBuilder->select('uid', 'calendarize')
+            ->from($table)
+            ->where(
+                $queryBuilder->expr()->orX(
+                    $queryBuilder->expr()->eq('calendarize', $uid),
+                    $queryBuilder->expr()->like('calendarize', $queryBuilder->createNamedParameter($uid . ',%')),
+                    $queryBuilder->expr()->like('calendarize', $queryBuilder->createNamedParameter('%,' . $uid)),
+                    $queryBuilder->expr()->like('calendarize', $queryBuilder->createNamedParameter('%,' . $uid . ',%'))
+                )
+            )->execute()->fetchAssociative();
     }
 }

--- a/Classes/ViewHelpers/Format/LineFoldingViewHelper.php
+++ b/Classes/ViewHelpers/Format/LineFoldingViewHelper.php
@@ -34,7 +34,7 @@ class LineFoldingViewHelper extends AbstractViewHelper
         return preg_replace(
             // Line folding after 75 characters: RFC-5545/3-1-content-lines
             // Base on: sabre/vobject
-             '/(
+            '/(
                  (?:^.)?         # 1 additional byte in first line because of missing single space (see next line)
                  .{74}           # 75 bytes per line (1 byte is used for a single space added after every CRLF)
                  (?![\x80-\xbf]) # prevent splitting multibyte characters


### PR DESCRIPTION
indexing must be done for the last (and only for the last!) configuration, which is published in the current publishing process. At this moment all data is live.

When indexing is done for the event and all configurations, only the first configuration will be indexed..?!