### PR TITLE
Fix 710 calendar download format

### DIFF
--- a/Classes/Controller/AbstractCompatibilityController.php
+++ b/Classes/Controller/AbstractCompatibilityController.php
@@ -34,7 +34,6 @@ if (GeneralUtility::makeInstance(Typo3Version::class)->getMajorVersion() > 10) {
         {
             $response = parent::callActionMethod($request);
             if (isset($this->feedFormats[$request->getFormat()])) {
-                $response = $this->sendHeaderAndFilename($response, $this->feedFormats[$request->getFormat()], $request->getFormat());
                 if ($request->hasArgument('hmac')) {
                     $hmac = $request->getArgument('hmac');
                     if ($this->validatePluginHmac($hmac)) {
@@ -93,7 +92,6 @@ if (GeneralUtility::makeInstance(Typo3Version::class)->getMajorVersion() > 10) {
         {
             parent::callActionMethod();
             if (isset($this->feedFormats[$this->request->getFormat()])) {
-                $this->sendHeaderAndFilename($this->feedFormats[$this->request->getFormat()], $this->request->getFormat());
                 if ($this->request->hasArgument('hmac')) {
                     $hmac = $this->request->getArgument('hmac');
                     if ($this->validatePluginHmac($hmac)) {

--- a/Classes/Controller/AbstractController.php
+++ b/Classes/Controller/AbstractController.php
@@ -154,8 +154,9 @@ abstract class AbstractController extends ActionController
         $actionMethodName = ucfirst($this->request->getControllerActionName());
         $pluginName = $this->request->getPluginName();
         $controllerName = $this->request->getControllerName();
+        $pluginUid = $this->configurationManager->getContentObject()->data['uid'];
 
-        return $controllerName . $pluginName . $actionMethodName;
+        return $controllerName . $pluginName . $actionMethodName . $pluginUid;
     }
 
     /**


### PR DESCRIPTION
This pull request would fix two issues with the calendar export files:

1. The `hmac` parameter is currently not unique on a single page. The `getStringForPluginHmac()` returns e.g. `CalendarCalendarList` (list view) or `CalendarCalendarMonth` (month view). Two list views or two month views will have the same `hmac`. By adding the content/plugin uid, the `hmac` will be unique.
2. Like assumed in #710, the current code will always send the calendar export file of the first plugin found. The `hmac` ist not taking into account. By removing on line, the intended logic is recovered: 
    * if a valid `hmac` is given, the export of the selected plugin is returned
    * otherwise the export of the first plugin found is used

This is a possible fix for #710.

With this patch and the following RouteEnhancer configuration, the links would look like:

1. One calendar on the page or the first found (`hmac` and `cHash` missing):

- https://example.com/export.xml
- https://example.com/export.ics
- https://example.com/export.atom

2. Export of two list views on the same page:

- https://example.com/export.ics?tx_calendarize_calendar%5Bhmac%5D=9705c82b28850c2aac668f508e9034d03bd8d351&cHash=5ce82b511f60c07fa77d017a20423e5b
- https://example.com/export.ics?tx_calendarize_calendar%5Bhmac%5D=965d725fdd217fe90af98eaad91a002d1b44d190&cHash=71b95a5c0cc4455772d092fffb3bf172

```
routeEnhancers:
  Calendarize:
    type: Extbase
    extension: Calendarize
    plugin: Calendar
    routes:
     - routePath: '/export.{format}'
       _controller: 'Calendar::list'
    defaultController: 'Calendar::list'
    aspects:
      format:
        type: StaticValueMapper
        map:
          'ics': 'ics'
          'atom': 'atom'
          'xml': 'xml'
```