### PR TITLE
fixing problem with office365 event UID

### DIFF
--- a/Classes/Domain/Model/ImportTrait.php
+++ b/Classes/Domain/Model/ImportTrait.php
@@ -11,7 +11,7 @@ trait ImportTrait
      *
      * @var string|null
      *
-     * @DatabaseField(sql="varchar(100) DEFAULT NULL")
+     * @DatabaseField(sql="varchar(150) DEFAULT NULL")
      */
     protected $importId;
 


### PR DESCRIPTION
I use importer for our appointments and take here an iCAL file from an Office365 calendar and here are apparently the UIDs longer than 100 characters, so it happens when importing that he can not match the appointments and thus always adds them and you see them multiple times. 

I have looked at the UIDs and they are always 113 characters long, so I would suggest that they be increased to 150 characters.

Here is an example of such a UID: 040000008200E00074C5B7101A82E008000000004AEAA27C9C3FD90100000000000010000000E0824392CEF5CF4D9CDBD3AD68431628