### PR TITLE
Update CalendarController.php

### DIFF
--- a/Classes/Controller/CalendarController.php
+++ b/Classes/Controller/CalendarController.php
@@ -394,12 +394,21 @@ class CalendarController extends AbstractCompatibilityController
     public function monthAction($year = null, $month = null, $day = null)
     {
         $this->addCacheTags(['calendarize_month']);
+        $arguments = $this->request->getArguments();
 
         $date = DateTimeUtility::normalizeDateTime($day, $month, $year);
         $now = DateTimeUtility::getNow();
         $useCurrentDate = $now->format('Y-m') === $date->format('Y-m');
-        if ($useCurrentDate) {
-            $date = $now;
+
+        if(isset($arguments['index'])) {
+            /** @var Index $index */
+            $index = $this->indexRepository->findByUid($arguments['index']);
+            $date = $index->getStartDate();
+        }
+        else {
+            if ($useCurrentDate) {
+                $date = $now;
+            }
         }
 
         if ($this->isDateOutOfTypoScriptConfiguration($date)) {


### PR DESCRIPTION
with this little change it is possible to place the event detail view on the same page as the month view. It solves following problem:
The month view shows april -> switch to may -> click on an event in may -> the detail view on the same page shows now the correct event detail, but the month view switches again to april.