### PR TITLE
Fix calendar export on pages with multiple calendarize plugins

### DIFF
--- a/Classes/Controller/CalendarController.php
+++ b/Classes/Controller/CalendarController.php
@@ -314,6 +314,12 @@ class CalendarController extends AbstractCompatibilityController
         $limit = 100,
         $sort = 'ASC'
     ) {
+        if ($this->request->hasArgument('format')) {
+            if ($this->request->getArgument('format') != 'html') {
+                return $this->return404Page();;
+            }
+        }
+
         $this->addCacheTags(['calendarize_past']);
 
         $limit = (int)($this->settings['limit']);
@@ -335,6 +341,12 @@ class CalendarController extends AbstractCompatibilityController
      */
     public function yearAction($year = null)
     {
+        if ($this->request->hasArgument('format')) {
+            if ($this->request->getArgument('format') != 'html') {
+                return $this->return404Page();;
+            }
+        }
+
         $this->addCacheTags(['calendarize_year']);
 
         // use the thrid day, to avoid time shift problems in the timezone
@@ -365,6 +377,12 @@ class CalendarController extends AbstractCompatibilityController
      */
     public function quarterAction(int $year = null, int $quarter = null)
     {
+        if ($this->request->hasArgument('format')) {
+            if ($this->request->getArgument('format') != 'html') {
+                return $this->return404Page();;
+            }
+        }
+
         $this->addCacheTags(['calendarize_quarter']);
 
         $quarter = DateTimeUtility::normalizeQuarter($quarter);
@@ -393,6 +411,12 @@ class CalendarController extends AbstractCompatibilityController
      */
     public function monthAction($year = null, $month = null, $day = null)
     {
+        if ($this->request->hasArgument('format')) {
+            if ($this->request->getArgument('format') != 'html') {
+                return $this->return404Page();;
+            }
+        }
+
         $this->addCacheTags(['calendarize_month']);
         $arguments = $this->request->getArguments();
 
@@ -433,6 +457,12 @@ class CalendarController extends AbstractCompatibilityController
      */
     public function weekAction(?int $year = null, ?int $week = null)
     {
+        if ($this->request->hasArgument('format')) {
+            if ($this->request->getArgument('format') != 'html') {
+                return $this->return404Page();;
+            }
+        }
+
         $this->addCacheTags(['calendarize_week']);
 
         $now = DateTimeUtility::getNow();
@@ -478,6 +508,12 @@ class CalendarController extends AbstractCompatibilityController
      */
     public function dayAction($year = null, $month = null, $day = null)
     {
+        if ($this->request->hasArgument('format')) {
+            if ($this->request->getArgument('format') != 'html') {
+                return $this->return404Page();;
+            }
+        }
+
         $this->addCacheTags(['calendarize_day']);
 
         $date = DateTimeUtility::normalizeDateTime($day, $month, $year);

--- a/Classes/Controller/CalendarController.php
+++ b/Classes/Controller/CalendarController.php
@@ -315,7 +315,7 @@ class CalendarController extends AbstractCompatibilityController
         $sort = 'ASC'
     ) {
         if ($this->request->hasArgument('format')) {
-            if ($this->request->getArgument('format') != 'html') {
+            if ('html' != $this->request->getArgument('format')) {
                 return $this->return404Page();
             }
         }
@@ -342,7 +342,7 @@ class CalendarController extends AbstractCompatibilityController
     public function yearAction($year = null)
     {
         if ($this->request->hasArgument('format')) {
-            if ($this->request->getArgument('format') != 'html') {
+            if ('html' != $this->request->getArgument('format')) {
                 return $this->return404Page();
             }
         }
@@ -378,7 +378,7 @@ class CalendarController extends AbstractCompatibilityController
     public function quarterAction(int $year = null, int $quarter = null)
     {
         if ($this->request->hasArgument('format')) {
-            if ($this->request->getArgument('format') != 'html') {
+            if ('html' != $this->request->getArgument('format')) {
                 return $this->return404Page();
             }
         }
@@ -412,7 +412,7 @@ class CalendarController extends AbstractCompatibilityController
     public function monthAction($year = null, $month = null, $day = null)
     {
         if ($this->request->hasArgument('format')) {
-            if ($this->request->getArgument('format') != 'html') {
+            if ('html' != $this->request->getArgument('format')) {
                 return $this->return404Page();
             }
         }
@@ -458,7 +458,7 @@ class CalendarController extends AbstractCompatibilityController
     public function weekAction(?int $year = null, ?int $week = null)
     {
         if ($this->request->hasArgument('format')) {
-            if ($this->request->getArgument('format') != 'html') {
+            if ('html' != $this->request->getArgument('format')) {
                 return $this->return404Page();
             }
         }
@@ -509,7 +509,7 @@ class CalendarController extends AbstractCompatibilityController
     public function dayAction($year = null, $month = null, $day = null)
     {
         if ($this->request->hasArgument('format')) {
-            if ($this->request->getArgument('format') != 'html') {
+            if ('html' != $this->request->getArgument('format')) {
                 return $this->return404Page();
             }
         }

--- a/Classes/Controller/CalendarController.php
+++ b/Classes/Controller/CalendarController.php
@@ -316,7 +316,7 @@ class CalendarController extends AbstractCompatibilityController
     ) {
         if ($this->request->hasArgument('format')) {
             if ($this->request->getArgument('format') != 'html') {
-                return $this->return404Page();;
+                return $this->return404Page();
             }
         }
 
@@ -343,7 +343,7 @@ class CalendarController extends AbstractCompatibilityController
     {
         if ($this->request->hasArgument('format')) {
             if ($this->request->getArgument('format') != 'html') {
-                return $this->return404Page();;
+                return $this->return404Page();
             }
         }
 
@@ -379,7 +379,7 @@ class CalendarController extends AbstractCompatibilityController
     {
         if ($this->request->hasArgument('format')) {
             if ($this->request->getArgument('format') != 'html') {
-                return $this->return404Page();;
+                return $this->return404Page();
             }
         }
 
@@ -413,7 +413,7 @@ class CalendarController extends AbstractCompatibilityController
     {
         if ($this->request->hasArgument('format')) {
             if ($this->request->getArgument('format') != 'html') {
-                return $this->return404Page();;
+                return $this->return404Page();
             }
         }
 
@@ -459,7 +459,7 @@ class CalendarController extends AbstractCompatibilityController
     {
         if ($this->request->hasArgument('format')) {
             if ($this->request->getArgument('format') != 'html') {
-                return $this->return404Page();;
+                return $this->return404Page();
             }
         }
 
@@ -510,7 +510,7 @@ class CalendarController extends AbstractCompatibilityController
     {
         if ($this->request->hasArgument('format')) {
             if ($this->request->getArgument('format') != 'html') {
-                return $this->return404Page();;
+                return $this->return404Page();
             }
         }
 


### PR DESCRIPTION
Possible fix for #753 .

Unfortunately, I cannot explain, what Extbase is doing here. In the described case, the "wrong" actions like `yearAction()` are called before the intended `listAction()`.

Maybe, there is a smoother solution for this?