### PR TITLE
[BUGFIX] make order by deterministic

### DIFF
--- a/Classes/Domain/Repository/IndexRepository.php
+++ b/Classes/Domain/Repository/IndexRepository.php
@@ -36,6 +36,7 @@ class IndexRepository extends AbstractRepository
     protected $defaultOrderings = [
         'start_date' => QueryInterface::ORDER_ASCENDING,
         'start_time' => QueryInterface::ORDER_ASCENDING,
+        'uid' => QueryInterface::ORDER_ASCENDING,
     ];
 
     /**
@@ -99,11 +100,13 @@ class IndexRepository extends AbstractRepository
             $query->setOrderings([
                 'start_date' => QueryInterface::ORDER_ASCENDING,
                 'start_time' => QueryInterface::ORDER_ASCENDING,
+                'uid' => QueryInterface::ORDER_ASCENDING,
             ]);
         } else {
             $query->setOrderings([
                 'start_date' => QueryInterface::ORDER_DESCENDING,
                 'start_time' => QueryInterface::ORDER_DESCENDING,
+                'uid' => QueryInterface::ORDER_DESCENDING,
             ]);
         }
 
@@ -674,6 +677,7 @@ class IndexRepository extends AbstractRepository
                 'endDate' => $direction,
                 'startDate' => $direction,
                 'startTime' => $direction,
+                'uid' => $direction,
             ];
         }
         if ('end' !== $field) {
@@ -683,6 +687,7 @@ class IndexRepository extends AbstractRepository
         return [
             $field . 'Date' => $direction,
             $field . 'Time' => $direction,
+            'uid' => $direction,
         ];
     }
 }

--- a/Classes/Domain/Repository/RawIndexRepository.php
+++ b/Classes/Domain/Repository/RawIndexRepository.php
@@ -102,6 +102,7 @@ class RawIndexRepository extends AbstractRawRepository
             )
             ->addOrderBy('start_date', 'ASC')
             ->addOrderBy('start_time', 'ASC')
+            ->addOrderBy('uid', 'ASC')
             ->setMaxResults($limit);
 
         $result = $queryBuilder->executeQuery()->fetchAllAssociative();


### PR DESCRIPTION
In the moment the default ordering for a list view is startDate ascending and startTime ascending. If several events have the exact same start date and time the order by is none deterministic. This is normal and expected behavior of MySQL. Problem is that MySQL
servers might produce different paginated lists. Lets say you display 2 events per page and have 4 events. The 2nd and 3rd event have the exact same start date and time. In my case the 2nd event is displayed again as 3rd event on page 2 of the pagination. The only way to get around this is to make the order by
deterministic by adding the uid field.

fixes #766