### PR TITLE
    [BUGFIX] Restrict ics-import to pid per calendar

### DIFF
--- a/Classes/Domain/Repository/EventRepository.php
+++ b/Classes/Domain/Repository/EventRepository.php
@@ -67,15 +67,20 @@ class EventRepository extends AbstractRepository
 
     /**
      * @param $importId
+     * @param $pid
      *
      * @return mixed|null
      */
-    public function findOneByImportId($importId)
+    public function findOneByImportId($importId, $pid)
     {
         $query = $this->createQuery();
         $query->getQuerySettings()->setRespectStoragePage(false);
         $query->getQuerySettings()->setIgnoreEnableFields(true);
-        $query->matching($query->equals('importId', $importId));
+
+        $query->matching($query->logicalAnd(
+            $query->equals('importId', $importId),
+            $query->equals('pid', $pid),
+        ));
         $result = $query->execute()->toArray();
 
         return $result[0] ?? null;

--- a/Classes/EventListener/ImportSingleIcalEventListener.php
+++ b/Classes/EventListener/ImportSingleIcalEventListener.php
@@ -61,7 +61,7 @@ class ImportSingleIcalEventListener
         $pid = $event->getPid();
 
         $importId = \strlen($calEvent->getUid()) <= 100 ? $calEvent->getUid() : md5($calEvent->getUid());
-        $eventObj = $this->initializeEventRecord($importId);
+        $eventObj = $this->initializeEventRecord($importId, $pid);
         $this->hydrateEventRecord($eventObj, $calEvent, $pid);
 
         if (null !== $eventObj->getUid() && (int)$eventObj->getUid() > 0) {
@@ -77,12 +77,13 @@ class ImportSingleIcalEventListener
      * Initializes or gets an event by import id.
      *
      * @param string $importId
+     * @param int    $pid
      *
      * @return Event
      */
-    private function initializeEventRecord(string $importId): Event
+    private function initializeEventRecord(string $importId, int $pid): Event
     {
-        $eventObj = $this->eventRepository->findOneByImportId($importId);
+        $eventObj = $this->eventRepository->findOneByImportId($importId, $pid);
 
         if (!($eventObj instanceof Event)) {
             $eventObj = new Event();


### PR DESCRIPTION
    If the calendar events are not restricted to the pid, where the ics
    import saves the events:
    Having two identical ics urls in different import schedules to
    different pages, the events are spread between these pages.

    This fix makes sure, that all events are imported to each target page.

    for v11 branch like #773 