### PR TITLE
fix compatibility with symfony expression language 7

### DIFF
--- a/Classes/Command/CleanupCommandController.php
+++ b/Classes/Command/CleanupCommandController.php
@@ -76,7 +76,7 @@ class CleanupCommandController extends Command
      * Cleanup the event models.
      * Remove outdated events to keep a small footprint. This gain maybe a little more performance.
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = new SymfonyStyle($input, $output);
         $io->title('Cleanup outdated events');

--- a/Classes/Command/ImportCommandController.php
+++ b/Classes/Command/ImportCommandController.php
@@ -61,7 +61,7 @@ class ImportCommandController extends Command
      *
      * @throws \Exception
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = new SymfonyStyle($input, $output);
 

--- a/Classes/Command/ReindexCommandController.php
+++ b/Classes/Command/ReindexCommandController.php
@@ -15,7 +15,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class ReindexCommandController extends Command
 {
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         /** @var IndexerService $indexer */
         $indexer = GeneralUtility::makeInstance(IndexerService::class);


### PR DESCRIPTION
After executing an composer update with TYPO3 12.4 the composer package "symfony/expression-language" gets updated to version 7 and the following php error occurs when setting up the extensions with "./vendor/bin/typo3 extension:setup":

Fatal error: Declaration of HDNET\Calendarize\Command\CleanupCommandController::execute(Symfony\Component\Console\Input\InputInterface $input, Symfony\Component\Console\Output\OutputInterface $output) must be compatible with Symfony\Component\Console\Command\Command::execute(Symfony\Component\Console\Input\InputInterface $input, Symfony\Component\Console\Output\OutputInterface $output): int

The same goes for the other two commands.