### PR TITLE
[BUGFIX] add more workspace criteria

### DIFF
--- a/Classes/Service/IndexPreparationService.php
+++ b/Classes/Service/IndexPreparationService.php
@@ -72,8 +72,12 @@ class IndexPreparationService extends AbstractService
     {
         $workspace = isset($record['t3ver_wsid']) ? (int)$record['t3ver_wsid'] : 0;
         $origId = isset($record['t3ver_oid']) ? (int)$record['t3ver_oid'] : 0;
-        $neededItems = array_map(static function ($item) use ($workspace, $origId, $record) {
+        $versionState = isset($record['t3ver_state']) ? (int)$record['t3ver_state'] : 0;
+        $versionStage = isset($record['t3ver_stage']) ? (int)$record['t3ver_stage'] : 0;
+        $neededItems = array_map(static function ($item) use ($workspace, $origId, $record, $versionState, $versionStage) {
             $item['t3ver_wsid'] = $workspace;
+            $item['t3ver_state'] = $versionState;
+            $item['t3ver_stage'] = $versionStage;
             // Set relation to the original record
             if ($workspace) {
                 $item['foreign_uid'] = $origId ?: (int)$record['uid'];


### PR DESCRIPTION
so the loading of the language information has more criteria to be more precise and prevent finding more than one matching translation

the last fix for #663 wasn't enough and let to exceptions because still more than one translation might be found.