### PR TITLE
[BUGFIX] Pass array to AbstractSchemaManager::tablesExist()

### DIFF
--- a/Classes/Updates/DateFieldUpdate.php
+++ b/Classes/Updates/DateFieldUpdate.php
@@ -81,7 +81,7 @@ class DateFieldUpdate extends AbstractUpdate
         /** @var Connection $connection */
         $connection = GeneralUtility::makeInstance(ConnectionPool::class)->getConnectionForTable($tableName);
         $schemaManager = $connection->createSchemaManager();
-        if (!$schemaManager->tablesExist($tableName)) {
+        if (!$schemaManager->tablesExist([$tableName])) {
             return false;
         }
 


### PR DESCRIPTION
Since doctrine/dbal 4.0 the method AbstractSchemaManager::tablesExist() no longer accepts a string. Pass an array instead to stay compatible with dbal 3 and 4.

https://github.com/doctrine/dbal/blob/4.0.0/UPGRADE.md#bc-break-changes-in-the-doctrinedbalschema-api-1

