### PR TITLE
Support custom item count for calendarize_info preview

### DIFF
--- a/Classes/Register.php
+++ b/Classes/Register.php
@@ -111,17 +111,13 @@ class Register
             ],
         ];
 
-        if($GLOBALS['TCA'][$tableName]['columns']['calendarize_info']['config']['parameters']['items']){
-            $items = $GLOBALS['TCA'][$tableName]['columns']['calendarize_info']['config']['parameters']['items'];
-        }
-        
         $GLOBALS['TCA'][$tableName]['columns']['calendarize_info'] = [
             'label' => 'LLL:EXT:calendarize/Resources/Private/Language/locallang.xlf:tca.information',
             'config' => [
                 'type' => 'none',
                 'renderType' => 'calendarizeInfoElement',
                 'parameters' => [
-                    'items' => $items ?? 10,
+                    'items' => $GLOBALS['TCA'][$tableName]['columns']['calendarize_info']['config']['parameters']['items'] ?? 10,
                 ],
             ],
         ];

--- a/Classes/Register.php
+++ b/Classes/Register.php
@@ -111,16 +111,21 @@ class Register
             ],
         ];
 
+        if($GLOBALS['TCA'][$tableName]['columns']['calendarize_info']['config']['parameters']['items']){
+            $items = $GLOBALS['TCA'][$tableName]['columns']['calendarize_info']['config']['parameters']['items'];
+        }
+        
         $GLOBALS['TCA'][$tableName]['columns']['calendarize_info'] = [
             'label' => 'LLL:EXT:calendarize/Resources/Private/Language/locallang.xlf:tca.information',
             'config' => [
                 'type' => 'none',
                 'renderType' => 'calendarizeInfoElement',
                 'parameters' => [
-                    'items' => 10,
+                    'items' => $items ?? 10,
                 ],
             ],
         ];
+
         ExtensionManagementUtility::addToAllTCAtypes(
             $tableName,
             $fieldName . ',calendarize_info',

--- a/Documentation/DeveloperManual/OwnEvents/Index.rst
+++ b/Documentation/DeveloperManual/OwnEvents/Index.rst
@@ -62,4 +62,4 @@ To modify the amount of items shown in the preview you can change the amount in 
 ..  code-block:: php
     :caption: EXT:some_extension/Configuration/TCA/Overrides/<tx_extension_domain_model_event>.php
 
-    $GLOBALS['TCA']['tx_myextension_domain_model_myevent']['columns']['calendarize_info']['config']['items'] = 25;
+    $GLOBALS['TCA']['tx_myextension_domain_model_myevent']['columns']['calendarize_info']['config']['parameters']['items'] = 25;


### PR DESCRIPTION
Updated Register.php to allow overriding the number of items shown in the calendarize_info preview via the TCA parameters. Adjusted documentation to reflect the correct way to set the item count using the 'parameters' array.

Problem was that 1st, documention is wrong, the current documention says 
<img width="965" height="286" alt="image" src="https://github.com/user-attachments/assets/989d081b-fe3e-4c88-b00a-a51624f9c7c1" />

But code is

        
```
        $GLOBALS['TCA'][$tableName]['columns']['calendarize_info'] = [
            'label' => 'LLL:EXT:calendarize/Resources/Private/Language/locallang.xlf:tca.information',
            'config' => [
                'type' => 'none',
                'renderType' => 'calendarizeInfoElement',
                'parameters' => [
                    'items' => 10,
                ],
            ],
        ];
        
        
```
Also for some reason I couldn't override your 10, so I did changes that 1st check is it set firstly in overrides or some other TCA, and if so, then use that custom number 1st and if not go to 10. 

Documentaion is creally wrong, but for this other issue maybe its my problem, but please test it, becouse I had same problem on two websites.

Thanks