### PR TITLE
[FEATURE] Add possibility to configure ICS links

### DIFF
--- a/Configuration/FlexForms/Calendar.xml
+++ b/Configuration/FlexForms/Calendar.xml
@@ -70,6 +70,25 @@
                             <type>check</type>
                         </config>
 					</settings.hidePagination>
+
+                    <settings.hideIcalLink>
+                        <label>LLL:EXT:calendarize/Resources/Private/Language/locallang.xlf:hide.link.ical</label>
+                        <displayCond>
+                            <OR>
+
+                                <numIndex index="0">FIELD:parentRec.list_type:=:calendarize_listdetail</numIndex>
+                                <numIndex index="1">FIELD:parentRec.list_type:=:calendarize_list</numIndex>
+                                <numIndex index="2">FIELD:parentRec.list_type:=:calendarize_latest</numIndex>
+                                <numIndex index="3">FIELD:parentRec.list_type:=:calendarize_result</numIndex>
+                                <numIndex index="4">FIELD:parentRec.list_type:=:calendarize_detail</numIndex>
+                                <!-- <numIndex index="5">FIELD:parentRec.list_type:=:calendarize_past</numIndex> -->
+                            </OR>
+                        </displayCond>
+                        <config>
+                            <type>check</type>
+                        </config>
+                    </settings.hideIcalLink>
+
 					<settings.useRelativeDate>
                         <label>LLL:EXT:calendarize/Resources/Private/Language/locallang.xlf:useRelativeDate</label>
                         <displayCond>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -425,6 +425,9 @@
 			<trans-unit id="hide.pagination.teaser">
 				<source>Hide pagination + Teaser mode</source>
 			</trans-unit>
+			<trans-unit id="hide.link.ical">
+				<source>Hide ICAL link</source>
+			</trans-unit>
 			<trans-unit id="override.startdate">
 				<source>Override startdate</source>
 			</trans-unit>

--- a/Resources/Private/Templates/Calendar/Detail.html
+++ b/Resources/Private/Templates/Calendar/Detail.html
@@ -15,8 +15,9 @@
 							<f:translate key="back"/>
 						</f:link.page>
 					</f:if>
-					<f:link.action action="detail" arguments="{index: index}" format="ics" class="btn btn-default">ICS/iCal
-					</f:link.action>
+                    <f:if condition="{settings.hideIcalLink} != 1">
+                        <f:link.action action="detail" arguments="{index: index}" format="ics" class="btn btn-default">ICS/iCal</f:link.action>
+                    </f:if>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
There is now a new checkbox in Flexform to configure whether to hide ICS links.

Currently, the links are only displayed in Detail.html, but the flexform field is added to other plugins as well.

In the Fluid Detail.html the ICS link is only set if settings.hideIcalLink is not set to 1 (so it is still displayed if setting was saved without new setting).

Resolves: #841