### PR TITLE
[BUGFIX] Makes sure PluginListTypeToCTypeUpdate works in v13

### DIFF
--- a/Classes/Updates/PluginListTypeToCTypeUpdate.php
+++ b/Classes/Updates/PluginListTypeToCTypeUpdate.php
@@ -4,8 +4,21 @@ declare(strict_types=1);
 
 namespace HDNET\Calendarize\Updates;
 
-use TYPO3\CMS\Core\Upgrades\AbstractListTypeToCTypeUpdate;
+// Use the EXT:install namespace to remain compatible with both v13 and v14
+// @todo Use v14 namespaces for UpgradeWizard and AbstractListTypeToCTypeUpdate when support for v13 is dropped
 
+// v14
+//use TYPO3\CMS\Core\Attribute\UpgradeWizard;
+// v13 path, works for v13 and v14
+use TYPO3\CMS\Install\Attribute\UpgradeWizard;
+
+// v14
+//use TYPO3\CMS\Core\Upgrades\AbstractListTypeToCTypeUpdate;
+// v13 path, works for v13 and v14
+use TYPO3\CMS\Install\Updates\AbstractListTypeToCTypeUpdate;
+
+
+#[UpgradeWizard('calendarize_pluginListTypeToCTypeUpdate')]
 class PluginListTypeToCTypeUpdate extends AbstractListTypeToCTypeUpdate
 {
     protected function getListTypeToCTypeMapping(): array


### PR DESCRIPTION
Add attribute UpgradeWizard to upgrade wizard PluginListTypeToCTypeUpdate so it will register automatically.

Current version of calendarize still supports v13 but upgrade wizard PluginListTypeToCTypeUpdate will not work in v13 because the namespaces for AbstractListTypeToCTypeUpdate and UpgradeWizard changed between v13 and v14. For this reason, the v13 paths should still be used as this will work in v13 and v14.

Resolves: #866