### PR TITLE
[TASK] Use calendarize icons in TCA

### DIFF
--- a/Configuration/TCA/Overrides/tt_content.php
+++ b/Configuration/TCA/Overrides/tt_content.php
@@ -28,11 +28,12 @@ $pluginNameAndGroup = array_merge(
 );
 
 foreach ($pluginNameAndGroup as $pluginName => $group) {
+    $pluginNameLowercase = strtolower($pluginName);
     $pluginSignature = TYPO3\CMS\Extbase\Utility\ExtensionUtility::registerPlugin(
         'calendarize',
         $pluginName,
-        $ll . 'mode.' . strtolower($pluginName),
-        null,
+        $ll . 'mode.' . $pluginNameLowercase,
+        'ext-calendarize-wizard-icon-' . $pluginNameLowercase,
         $group,
     );
     // Disable the display of layout and select_key fields for the plugin


### PR DESCRIPTION
In TCA, the corresponding icons from Icons.php will be used for each plugin. This way, the calendarize icons are displayed instead of the general plugin icon in the backend.

Resolves: #869

-----

After the change it looks like this:

<img width="281" height="188" alt="image" src="https://github.com/user-attachments/assets/a1878df7-a694-4e36-8655-a8883df4067a" />

<img width="305" height="226" alt="image" src="https://github.com/user-attachments/assets/0bb37de9-8366-4200-98ac-9827ed0b8dcd" />

<img width="181" height="84" alt="image" src="https://github.com/user-attachments/assets/16409b07-e29a-43ab-9fe1-11d4ef98d066" />
