### PR TITLE
[TASK] Move all content elements to one group again

### DIFF
--- a/Configuration/TCA/Overrides/tt_content.php
+++ b/Configuration/TCA/Overrides/tt_content.php
@@ -6,26 +6,21 @@ defined('TYPO3') or exit();
 
 $ll = 'LLL:EXT:calendarize/Resources/Private/Language/locallang.xlf:';
 
-foreach (['normal', 'special', 'booking'] as $itemGroup) {
-    TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTcaSelectItemGroup(
-        'tt_content',
-        'CType',
-        'calendarize_' . $itemGroup,
-        $ll . 'mode.' . $itemGroup,
-    );
-}
-
-$pluginNameAndGroup = array_merge(
-    array_fill_keys(
-        ['ListDetail', 'List', 'Detail', 'Search', 'Result', 'Latest', 'Single'],
-        'calendarize_normal',
-    ),
-    array_fill_keys(
-        ['Year', 'Quarter', 'Month', 'Week', 'Day', 'Past'],
-        'calendarize_special',
-    ),
-    ['Booking' => 'calendarize_booking'],
+TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTcaSelectItemGroup(
+    'tt_content',
+    'CType',
+    'calendarize',
+    'Calendarize',
 );
+
+$pluginNameAndGroup = array_fill_keys(
+        [
+            'ListDetail', 'List', 'Detail', 'Search', 'Result', 'Latest', 'Single',
+            'Year', 'Quarter', 'Month', 'Week', 'Day', 'Past',
+            'Booking',
+        ],
+        'calendarize',
+    );
 
 foreach ($pluginNameAndGroup as $pluginName => $group) {
     $pluginNameLowercase = strtolower($pluginName);


### PR DESCRIPTION
In TCA, the calendarize elements were split up into 3 to 4 groups in calendarize version v15 and were thus displayed in different tabs in the "New content element wizard".

We now revert to the old style with only one tab. This can still be configured differently with TCA or TSconfig if deemed necessary.

Resolves: #871

-----

**Additional note (not in commit):** I used the label "_Calendarize_" as header for the group. In previous version a hard coded string "_Calendarize elements_" was used so this was not localized. I think just "Calendarize" is better as it is shorter and there is no need to translate it, but if necessasry, a language label can be added in another commit. 

The existing language labels for the groups are IMHO not useful to be reused in this 1 group scenario:

* "Calendarize Elements" (no localizaton)
* "Calendarize - Booking" => locallang.xlf: mode.booking
* "Calendarize - Normal" => locallang.xlf: mode.normal
* "Calendarize - Special Views" => locallang.xlf: mode.special

They could theoretically be removed but extension authors might be using them (I consider this pretty unlikely, but possible). 