### PR TITLE
[TASK] Remove redundant icon + label from page preview

### DIFF
--- a/Classes/EventListener/PreviewRenderingEventListener.php
+++ b/Classes/EventListener/PreviewRenderingEventListener.php
@@ -43,11 +43,7 @@ class PreviewRenderingEventListener
             return;
         }
 
-        $extensionIconUsage = $this->iconFactory->getIcon('ext-calendarize-wizard-icon', IconSize::SMALL)->render();
-        $this->layoutService->setTitle($extensionIconUsage . ' Calendarize');
-
-        $listType = explode('_', $record[$listTypeField], 2)[1] ?? '';
-        $this->layoutService->addRow(TranslateUtility::get('mode'), TranslateUtility::get('mode.' . $listType));
+        $this->layoutService->setTitle(' Calendarize');
 
         $pluginConfiguration = (int)$this->flexFormService->get('settings.pluginConfiguration', 'main');
         if ($pluginConfiguration) {


### PR DESCRIPTION
Due to plugins icons already being configured in TCA now, showing the icons and mode in page preview via page preview renderer is obsolete.

Resolves: #874
Related: #869